### PR TITLE
continuous integration builds on travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: cpp
+compiler: gcc
+
+env:
+  - EPICS_BASE=/usr/lib/epics EPICS_HOST_ARCH=linux-x86_64
+  
+before_install:
+  # Enabling the NSLS-II EPICS debian package repositories
+  - curl http://epics.nsls2.bnl.gov/debian/repo-key.pub | sudo apt-key add -
+  - echo "deb http://epics.nsls2.bnl.gov/debian/ wheezy main contrib" | sudo tee -a /etc/apt/sources.list
+  - echo "deb-src http://epics.nsls2.bnl.gov/debian/ wheezy main contrib" | sudo tee -a /etc/apt/sources.list
+  
+  # Installing EPICS base
+  - sudo apt-get update -qq
+  - sudo apt-get install epics-dev epics-synapps-dev
+  
+  # Setup configure/RELEASE for the environment
+  - echo "EPICS_BASE=/usr/lib/epics" > configure/RELEASE
+  - echo "SNCSEQ=/usr/lib/epics" >> configure/RELEASE
+
+install: 
+  # Build the module
+  - make
+
+# Run the tests. Currently we have no fully automatic tests to run, 
+# so we just list the build products...
+script:
+  - ls bin/linux-x86_64
+  - ls lib/linux-x86_64
+  - ls include
+
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/epics-modules/asyn.svg?branch=master)](https://travis-ci.org/epics-modules/asyn)
+
 asyn
 ====
 This is a general purpose facility for interfacing device specific


### PR DESCRIPTION
This is a small addition of a .travis.yml configuration file which let's the www.travis-ci.org service automatically build this module. The automatic builds are triggered by events like Push, Pull Request and Pull Request updates.

The EPICS dependencies (base and seq) are pulled in from the NSLS-II debian repositories.

Currently there are no fully automatic tests in this module - the tests all leave an interactive EPICS IOC shell hanging around. If we later do some modifications to the tests and make them fully automatic then travis can also be configured to run these after each build.
