### PR TITLE
drvAsynIPPort: Add USERFLAG_CLOSE_ON_READ_TIMEOUT

### DIFF
--- a/documentation/asynDriver.html
+++ b/documentation/asynDriver.html
@@ -5479,6 +5479,11 @@ asynOctetSetOutputEos("A1",0,"\r")
   <pre>   drvAsynIPPortConfigure("portName","hostInfo",priority,noAutoConnect,
         noProcessEos)</pre>
   <p>
+    or with the <tt>drvAsynIPPortConfigure2</tt>
+  command:</p>
+  <pre>   drvAsynIPPortConfigure("portName","hostInfo",priority,noAutoConnect,
+        noProcessEos, userFlags)</pre>
+  <p>
     where the arguments are:</p>
   <ul>
     <li>portName - The portName that is registered with asynManager.</li>
@@ -5513,6 +5518,13 @@ asynOctetSetOutputEos("A1",0,"\r")
       connect. Non-zero if explicit connect command must be issued.</li>
     <li>noProcessEos If 0 then asynInterposeEosConfig is called specifying both processEosIn
       and processEosOut.</li>
+    <li>userFlags: bit-wise ored:
+      <ul>
+        <li>Bit 0 is USERFLAG_CLOSE_ON_READ_TIMEOUT, the (TCP) socket will 
+          be closed when read() returns a timeout. </li>
+        <li>Bit 1--31 are reserved, set to zero. </li>
+      </ul>
+    </li>
   </ul>
   <p>
     Only asynOctet methods write, read, and flush are implemented. Calling the other


### PR DESCRIPTION
Different EPICS records may share one TCP/IP connection (like different
axes at the same motion controller unit).

When the cable is pulled, TCP will buffer data send buffer,
and the readIt() function will return a timeout.

The default timeout is 2.0 seconds, and after this timeout the first axis
is put into the alarm state.

The next axis will need another 2 seconds on it's own, and for an 8-axes
system all axes are in alarm state after 16 seconds.

On the other hand, all the poll() requests are still in the send buffer,
so when the cable is put back, all 8 poll() requests are send to the
controller at once.

This may be a non-ideal situation: The controller must process many
messages at once, and a bunch of responses is send to the IOC.
The IOC should discard them all in flushIt(), or they may end up on the wrong
axis, depending on the timing.

Make it possible to close() the TCP connection already at the first timeout.
This means that all axes go into the alarm state at the same time,
and all data coming back from the controller are reliable discarded in the
TCP layer.

The new feature can be activated like this:
drvAsynIPPortConfigure2("MC_CPU1","192.168.1.15:5024",0,0,0,1)