### PR TITLE
drvAsynIPPort.c: Print when 0 length is received

### DIFF
--- a/asyn/drvAsynSerial/drvAsynIPPort.c
+++ b/asyn/drvAsynSerial/drvAsynIPPort.c
@@ -730,7 +730,7 @@ static asynStatus readIt(void *drvPvt, asynUser *pasynUser,
         osiSockAddr oa;
         unsigned int addrlen = sizeof(oa.ia);
         thisRead = recvfrom(tty->fd, data, (int)maxchars, 0, &oa.sa, &addrlen);
-        if (thisRead > 0) {
+        if (thisRead >= 0) {
             if (pasynTrace->getTraceMask(pasynUser) & ASYN_TRACEIO_DRIVER) {
                 char inetBuff[32];
                 ipAddrToDottedIP(&oa.ia, inetBuff, sizeof(inetBuff));
@@ -742,7 +742,7 @@ static asynStatus readIt(void *drvPvt, asynUser *pasynUser,
         }
     } else {
         thisRead = recv(tty->fd, data, (int)maxchars, 0);
-        if (thisRead > 0) {
+        if (thisRead >= 0) {
             asynPrintIO(pasynUser, ASYN_TRACEIO_DRIVER, data, thisRead,
                         "%s read %d\n", tty->IPDeviceName, thisRead);
             tty->nRead += (unsigned long)thisRead;


### PR DESCRIPTION
When recv() is called on stream socket, there are types of return value:
- thisRead < 0  means an error, and an error is printed
- thisRead == 0 means "end of file", the remote has closed the socket.
- thisRead >  0 means data has been received.

For a datagram socket thisRead == 0 means that a datagram with no payload was
received. Even if unusual, there is nothing wrong with that, because this
can be used as a e.g. "wakeup signal" or for other sort of signaling.

Today there is no log printout for thisRead == 0, which makes debugging
unnecessary harder than needed.

Add printouts for both stram and datagram sockets.