### PR TITLE
Added guard against null in paramVal::setString

### DIFF
--- a/asyn/asynPortDriver/paramVal.cpp
+++ b/asyn/asynPortDriver/paramVal.cpp
@@ -195,6 +195,8 @@ void paramVal::setString(const char *value)
 {
     if (type != asynParamOctet)
         throw ParamValWrongType("paramVal::setString can only handle asynParamOctet");
+    if (value == NULL)
+        throw ParamValWrongType("paramVal::setString can only handle non-NULL values");
     if (!isDefined() || (strcmp(data.sval, value)))
     {
         setDefined(true);


### PR DESCRIPTION
Found during aravisGigE testing.
Will post a pull request to aravisGigE soon which checks for NULL on that end as well.