### PR TITLE
Modified trace to call fflush on files as well as stdout and stderr.

### DIFF
--- a/asyn/asynDriver/asynManager.c
+++ b/asyn/asynDriver/asynManager.c
@@ -2800,7 +2800,7 @@ static int traceVprintSource(asynUser *pasynUser,int reason, const char *file, i
     } else {
         nout += errlogVprintf(pformat,pvar);
     }
-    if(fp==stdout || fp==stderr) fflush(fp);
+    fflush(fp);
     epicsMutexUnlock(pasynBase->lockTrace);
     return nout;
 }
@@ -2904,7 +2904,7 @@ static int traceVprintIOSource(asynUser *pasynUser,int reason,
             nout += errlogPrintf("\n");
         }
     }
-    if(fp==stdout || fp==stderr) fflush(fp);
+    fflush(fp);
     epicsMutexUnlock(pasynBase->lockTrace);
     return nout;
 }


### PR DESCRIPTION
Otherwise if the ioc crashes or is restarted, trace output is lost.
Also, you can't see the trace file output as new msgs are written without waiting for
a full I/O buffer.