### PR TITLE
Add RS485 support to drvAsynSerialPort driver

### DIFF
--- a/asyn/drvAsynSerial/os/Linux/serial_rs485.h
+++ b/asyn/drvAsynSerial/os/Linux/serial_rs485.h
@@ -1,0 +1,11 @@
+#ifndef SERIAL_RS485
+#define SERIAL_RS485
+
+#include <sys/ioctl.h>
+#include <linux/serial.h>
+
+#define TIOCGRS485      0x542E
+#define TIOCSRS485      0x542F
+
+#endif
+

--- a/asyn/drvAsynSerial/os/default/serial_rs485.h
+++ b/asyn/drvAsynSerial/os/default/serial_rs485.h
@@ -1,0 +1,16 @@
+#define SER_RS485_ENABLED         0x1
+#define SER_RS485_RTS_ON_SEND     0x2
+#define SER_RS485_RTS_AFTER_SEND  0x4
+
+#define TIOCGRS485      0x542E
+#define TIOCSRS485      0x542F
+
+struct serial_rs485 {
+  int flags;
+  unsigned int delay_rts_before_send;
+  unsigned int delay_rts_after_send;
+};
+
+int ioctl( int fd, unsigned long request, void* ptr ) {
+  return 0;
+}

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -1,15 +1,15 @@
 #RELEASE Location of external products
 
-SUPPORT=/corvette/home/epics/devel
+SUPPORT=/opt/epics/modules
 -include $(TOP)/../configure/SUPPORT.$(EPICS_HOST_ARCH)
 
 #  IPAC is only necessary if support for Greensprings IP488 is required
 #  IPAC release V2-7 or later is required.
-IPAC=$(SUPPORT)/ipac-2-13
+#IPAC=$(SUPPORT)/ipac-2-13
 
 # SEQ is required for testIPServer
-SNCSEQ=$(SUPPORT)/seq-2-2-3
+#SNCSEQ=$(SUPPORT)/seq-2-2-3
 
 #  EPICS_BASE 3.14.6 or later is required
-EPICS_BASE=/corvette/usr/local/epics/base-3.14.12.5
+EPICS_BASE=/opt/epics/base
 -include $(TOP)/../configure/EPICS_BASE.$(EPICS_HOST_ARCH)


### PR DESCRIPTION
Under linux RS485 interfaces can be controlled via the kernel dirver.
For this, the struct serial_rs485 defined in linux/serial.h has to be used.

The settings for RS485 are added as asynOptions to the drvAsynSerialPort:
rs485_enable                -- Enable RS485 support for interface in kernel
rs485_rts_on_send           -- Set logic level of RTS signal while sending ('Y' = HIGH)
rs485_rts_after_send        -- Set logic level of RTS signal after sending ('Y' = HIGH)
rs485_delay_rts_before_send -- Delay before send (milliseconds)
rs485_delay_rts_after_send  -- Delay after send (milliseconds)