### PR TITLE
Fixing minor typos in asynInterposeCom comments

### DIFF
--- a/asyn/miscellaneous/asynInterposeCom.c
+++ b/asyn/miscellaneous/asynInterposeCom.c
@@ -126,7 +126,7 @@ expectChar(interposePvt *pinterposePvt, asynUser *pasynUser, int expect)
 
 /*
  * Double up IAC characters.
- * We assume that memchr and memcpy are  nicely optimized so we're better of
+ * We assume that memchr and memcpy are nicely optimized so we're better off
  * using them than looking at and copying the characters one at a time ourself.
  */
 static asynStatus
@@ -699,7 +699,7 @@ asynInterposeCOM(const char *portName)
     asynUser *pasynUser;
 
     /*
-     * Interpose ourselve
+     * Interpose ourselves
      */
     pinterposePvt = callocMustSucceed(1, sizeof(interposePvt), "asynInterposeCOM");
     pinterposePvt->xBuf = NULL;

--- a/asyn/miscellaneous/asynInterposeCom.c
+++ b/asyn/miscellaneous/asynInterposeCom.c
@@ -127,7 +127,7 @@ expectChar(interposePvt *pinterposePvt, asynUser *pasynUser, int expect)
 /*
  * Double up IAC characters.
  * We assume that memchr and memcpy are nicely optimized so we're better off
- * using them than looking at and copying the characters one at a time ourself.
+ * using them than looking at and copying the characters one at a time ourselves.
  */
 static asynStatus
 writeIt(void *ppvt, asynUser *pasynUser,


### PR DESCRIPTION
Very minor.  Fixed a couple typos in asynInterposeCom.c comments.