### PR TITLE
Introduce clearParamValueChanged() and hasParamValueChanged() methods.

### DIFF
--- a/asyn/asynPortDriver/asynPortDriver.h
+++ b/asyn/asynPortDriver/asynPortDriver.h
@@ -167,6 +167,10 @@ public:
     virtual asynStatus updateTimeStamp(epicsTimeStamp *pTimeStamp);
     virtual asynStatus getTimeStamp(epicsTimeStamp *pTimeStamp);
     virtual asynStatus setTimeStamp(const epicsTimeStamp *pTimeStamp);
+    virtual asynStatus clearParamValueChanged(          int index);
+    virtual asynStatus clearParamValueChanged(int list, int index);
+    virtual asynStatus hasParamValueChanged(          int index, int *changed);
+    virtual asynStatus hasParamValueChanged(int list, int index, int *changed);
     asynStandardInterfaces *getAsynStdInterfaces();
     virtual void reportParams(FILE *fp, int details);
 


### PR DESCRIPTION
Allows the user to check if the parameter value changed. Useful if
acting on hardware must be a delayed action.

I still need to do more testing in order to better verify the functionality.

See also #46.