### PR TITLE
Added getParamType methods

### DIFF
--- a/asyn/asynPortDriver/asynPortDriver.cpp
+++ b/asyn/asynPortDriver/asynPortDriver.cpp
@@ -1,6 +1,6 @@
 /*
  * asynPortDriver.cpp
- * 
+ *
  * Base class that implements methods for asynStandardInterfaces with a parameter library.
  *
  * Author: Mark Rivers
@@ -23,7 +23,7 @@
 /* NOTE: interruptAccept is define in dbAccess.h if using EPICS IOC, else set it to 1 */
 #ifdef EPICS_LIBCOM_ONLY
     static int interruptAccept=1;
-#else 
+#else
     #include <dbAccess.h>
 #endif
 
@@ -279,7 +279,7 @@ asynStatus paramList::getInteger(int index, int *value)
 {
     asynStatus status;
     *value = 0;
-    
+
     try {
         paramVal *pVal = getParameter(index);
         *value = pVal->getInteger();
@@ -307,7 +307,7 @@ asynStatus paramList::getUInt32(int index, epicsUInt32 *value, epicsUInt32 mask)
 {
     asynStatus status;
     *value = 0;
-    
+
     try {
         paramVal *pVal = getParameter(index);
         *value = pVal->getUInt32(mask);
@@ -334,7 +334,7 @@ asynStatus paramList::getDouble(int index, double *value)
 {
     asynStatus status;
     *value = 0.;
-    
+
     try {
         paramVal *pVal = getParameter(index);
         *value = pVal->getDouble();
@@ -493,7 +493,7 @@ asynStatus paramList::getUInt32Interrupt(int index, epicsUInt32 *mask, interrupt
 asynStatus paramList::getString(int index, int maxChars, char *value)
 {
     asynStatus status=asynSuccess;
-    
+
     try {
         if (maxChars > 0) {
             paramVal *pVal = getParameter(index);
@@ -522,7 +522,7 @@ asynStatus paramList::getString(int index, int maxChars, char *value)
 asynStatus paramList::getString(int index, std::string& value)
 {
     asynStatus status=asynSuccess;
-    
+
     try {
         paramVal *pVal = getParameter(index);
         status = pVal->getStatus();
@@ -814,14 +814,14 @@ paramVal* paramList::getParameter(int index)
 static void callbackTaskC(void *drvPvt)
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
-    
+
     pPvt->callbackTask();
 }
 
 void asynPortDriver::callbackTask()
 {
     int addr;
-    
+
     while(!interruptAccept) epicsThreadSleep(0.1);
     epicsMutexLock(this->mutexId);
     for (addr=0; addr<this->maxAddr; addr++) {
@@ -866,7 +866,7 @@ asynStatus asynPortDriver::createParam(const char *name, asynParamType type, int
 {
     int list;
     asynStatus status;
-    
+
     /* All parameters lists support the same parameters, so add the parameter name to all lists */
     for (list=0; list<this->maxAddr; list++) {
         status = createParam(list, name, type, index);
@@ -885,7 +885,7 @@ asynStatus asynPortDriver::createParam(int list, const char *name, asynParamType
 {
     asynStatus status;
     static const char *functionName = "createParam";
-    
+
     status = this->params[list]->createParam(name, type, index);
     if (status == asynParamAlreadyExists) {
         asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
@@ -940,7 +940,25 @@ asynStatus asynPortDriver::getParamName(int list, int index, const char **name)
     return this->params[list]->getName(index, name);
 }
 
-/** Reports errors when setting parameters.  
+/** Returns the asynParamType of a parameter in the parameter library*
+    \param[in] index Parameter number
+  * \param[out] type Parameter type */
+asynStatus asynPortDriver::getParamType(          int index, asynParamType *type)
+{
+  return this->getParamType(0, index, type);
+}
+
+/** Returns the asynParamType of a parameter in the parameter library
+    \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
+    \param[in] index Parameter number
+  * \param[out] type Parameter type */
+asynStatus asynPortDriver::getParamType(int list, int index, asynParamType *type)
+{
+  *type = this->params[list]->getParameter(index)->type;
+  return asynSuccess;
+}
+
+/** Reports errors when setting parameters.
   * \param[in] status The error status.
   * \param[in] index The parameter number
   * \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
@@ -961,7 +979,7 @@ void asynPortDriver::reportSetParamErrors(asynStatus status, int index, int list
 
 /** Sets the status for a parameter in the parameter library.
   * Calls setParamStatus(0, index, status) i.e. for parameter list 0.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[in] status Status to set. */
 asynStatus asynPortDriver::setParamStatus(int index, asynStatus status)
 {
@@ -971,13 +989,13 @@ asynStatus asynPortDriver::setParamStatus(int index, asynStatus status)
 /** Sets the status for a parameter in the parameter library.
   * Calls paramList::setStatus(index, status) for the parameter list indexed by list.
   * \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[in] paramStatus Status to set. */
 asynStatus asynPortDriver::setParamStatus(int list, int index, asynStatus paramStatus)
 {
     asynStatus status;
     static const char *functionName = "setParamStatus";
-    
+
     status = this->params[list]->setStatus(index, paramStatus);
     if (status) reportSetParamErrors(status, index, list, functionName);
     return(status);
@@ -985,7 +1003,7 @@ asynStatus asynPortDriver::setParamStatus(int list, int index, asynStatus paramS
 
 /** Gets the status for a parameter in the parameter library.
   * Calls getParamStatus(0, index, status) i.e. for parameter list 0.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[out] status Address of tatus to get. */
 asynStatus asynPortDriver::getParamStatus(int index, asynStatus *status)
 {
@@ -995,7 +1013,7 @@ asynStatus asynPortDriver::getParamStatus(int index, asynStatus *status)
 /** Gets the status for a parameter in the parameter library.
   * Calls paramList::setStatus(index, status) for the parameter list indexed by list.
   * \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[out] paramStatus Address of status to get. */
 asynStatus asynPortDriver::getParamStatus(int list, int index, asynStatus *paramStatus)
 {
@@ -1009,7 +1027,7 @@ asynStatus asynPortDriver::getParamStatus(int list, int index, asynStatus *param
 
 /** Sets the alarmStatus for a parameter in the parameter library.
   * Calls setParamAlarmStatus(0, index, status) i.e. for parameter list 0.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[in] alarmStatus Status to set. */
 asynStatus asynPortDriver::setParamAlarmStatus(int index, int alarmStatus)
 {
@@ -1019,13 +1037,13 @@ asynStatus asynPortDriver::setParamAlarmStatus(int index, int alarmStatus)
 /** Sets the alarmStatus for a parameter in the parameter library.
   * Calls paramList::setAlarmStatus(index, status) for the parameter list indexed by list.
   * \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[in] alarmStatus Status to set. */
 asynStatus asynPortDriver::setParamAlarmStatus(int list, int index, int alarmStatus)
 {
     asynStatus status;
     static const char *functionName = "setParamAlarmStatus";
-    
+
     status = this->params[list]->setAlarmStatus(index, alarmStatus);
     if (status) reportSetParamErrors(status, index, list, functionName);
     return(status);
@@ -1033,7 +1051,7 @@ asynStatus asynPortDriver::setParamAlarmStatus(int list, int index, int alarmSta
 
 /** Gets the alarmStatus for a parameter in the parameter library.
   * Calls getParamAlarmStatus(0, index, status) i.e. for parameter list 0.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[out] alarmStatus Address of alarmStatus to get. */
 asynStatus asynPortDriver::getParamAlarmStatus(int index, int *alarmStatus)
 {
@@ -1043,7 +1061,7 @@ asynStatus asynPortDriver::getParamAlarmStatus(int index, int *alarmStatus)
 /** Gets the alarmStatus for a parameter in the parameter library.
   * Calls paramList::getAlarmStatus(index, status) for the parameter list indexed by list.
   * \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[out] alarmStatus Address of status to get. */
 asynStatus asynPortDriver::getParamAlarmStatus(int list, int index, int *alarmStatus)
 {
@@ -1057,7 +1075,7 @@ asynStatus asynPortDriver::getParamAlarmStatus(int list, int index, int *alarmSt
 
 /** Sets the alarmSeverity for a parameter in the parameter library.
   * Calls setParamAlarmSeverity(0, index, status) i.e. for parameter list 0.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[in] alarmSeverity Severity to set. */
 asynStatus asynPortDriver::setParamAlarmSeverity(int index, int alarmSeverity)
 {
@@ -1067,13 +1085,13 @@ asynStatus asynPortDriver::setParamAlarmSeverity(int index, int alarmSeverity)
 /** Sets the alarmSeverity for a parameter in the parameter library.
   * Calls paramList::setAlarmSeverity(index, status) for the parameter list indexed by list.
   * \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[in] alarmSeverity Severity to set. */
 asynStatus asynPortDriver::setParamAlarmSeverity(int list, int index, int alarmSeverity)
 {
     asynStatus status;
     static const char *functionName = "setParamAlarmSeverity";
-    
+
     status = this->params[list]->setAlarmSeverity(index, alarmSeverity);
     if (status) reportSetParamErrors(status, index, list, functionName);
     return(status);
@@ -1081,7 +1099,7 @@ asynStatus asynPortDriver::setParamAlarmSeverity(int list, int index, int alarmS
 
 /** Gets the alarmSeverity for a parameter in the parameter library.
   * Calls getParamAlarmSeverity(0, index, status) i.e. for parameter list 0.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[out] alarmSeverity Address of alarmSeverity to get. */
 asynStatus asynPortDriver::getParamAlarmSeverity(int index, int *alarmSeverity)
 {
@@ -1091,7 +1109,7 @@ asynStatus asynPortDriver::getParamAlarmSeverity(int index, int *alarmSeverity)
 /** Gets the alarmSeverity for a parameter in the parameter library.
   * Calls paramList::getAlarmSeverity(index, status) for the parameter list indexed by list.
   * \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[out] alarmSeverity Address of status to get. */
 asynStatus asynPortDriver::getParamAlarmSeverity(int list, int index, int *alarmSeverity)
 {
@@ -1105,7 +1123,7 @@ asynStatus asynPortDriver::getParamAlarmSeverity(int list, int index, int *alarm
 
 /** Sets the value for an integer in the parameter library.
   * Calls setIntegerParam(0, index, value) i.e. for parameter list 0.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[in] value Value to set. */
 asynStatus asynPortDriver::setIntegerParam(int index, int value)
 {
@@ -1115,13 +1133,13 @@ asynStatus asynPortDriver::setIntegerParam(int index, int value)
 /** Sets the value for an integer in the parameter library.
   * Calls paramList::setInteger (index, value) for the parameter list indexed by list.
   * \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[in] value Value to set. */
 asynStatus asynPortDriver::setIntegerParam(int list, int index, int value)
 {
     asynStatus status;
     static const char *functionName = "setIntegerParam";
-    
+
     status = this->params[list]->setInteger(index, value);
     if (status) reportSetParamErrors(status, index, list, functionName);
     return(status);
@@ -1129,8 +1147,8 @@ asynStatus asynPortDriver::setIntegerParam(int list, int index, int value)
 
 /** Sets the value for a UInt32Digital in the parameter library.
   * Calls setUIntDigitalParam(0, index, value, valueMask, 0) i.e. for parameter list 0.
-  * \param[in] index The parameter number 
-  * \param[in] value Value to set. 
+  * \param[in] index The parameter number
+  * \param[in] value Value to set.
   * \param[in] valueMask The mask to use when setting the value. */
 asynStatus asynPortDriver::setUIntDigitalParam(int index, epicsUInt32 value, epicsUInt32 valueMask)
 {
@@ -1140,8 +1158,8 @@ asynStatus asynPortDriver::setUIntDigitalParam(int index, epicsUInt32 value, epi
 /** Sets the value for a UInt32Digital in the parameter library.
   * Calls paramList::setUIntDigitalParam(list, index, value, valueMask, 0) for the parameter list indexed by list.
   * \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
-  * \param[in] index The parameter number 
-  * \param[in] value Value to set. 
+  * \param[in] index The parameter number
+  * \param[in] value Value to set.
   * \param[in] valueMask The mask to use when setting the value. */
 asynStatus asynPortDriver::setUIntDigitalParam(int list, int index, epicsUInt32 value, epicsUInt32 valueMask)
 {
@@ -1150,9 +1168,9 @@ asynStatus asynPortDriver::setUIntDigitalParam(int list, int index, epicsUInt32 
 
 /** Sets the value for a UInt32Digital in the parameter library.
   * Calls setUIntDigitalParam(0, index, value, valueMask, interruptMask) i.e. for parameter list 0.
-  * \param[in] index The parameter number 
-  * \param[in] value Value to set. 
-  * \param[in] valueMask The mask to use when setting the value. 
+  * \param[in] index The parameter number
+  * \param[in] value Value to set.
+  * \param[in] valueMask The mask to use when setting the value.
   * \param[in] interruptMask A mask that indicates which bits have changed even if the value is the same, so callbacks will be done */
 asynStatus asynPortDriver::setUIntDigitalParam(int index, epicsUInt32 value, epicsUInt32 valueMask, epicsUInt32 interruptMask)
 {
@@ -1162,15 +1180,15 @@ asynStatus asynPortDriver::setUIntDigitalParam(int index, epicsUInt32 value, epi
 /** Sets the value for a UInt32Digital in the parameter library.
   * Calls paramList::setInteger (index, value) for the parameter list indexed by list.
   * \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
-  * \param[in] index The parameter number 
-  * \param[in] value Value to set 
-  * \param[in] valueMask The mask to use when setting the value. 
+  * \param[in] index The parameter number
+  * \param[in] value Value to set
+  * \param[in] valueMask The mask to use when setting the value.
   * \param[in] interruptMask A mask that indicates which bits have changed even if the value is the same, so callbacks will be done */
 asynStatus asynPortDriver::setUIntDigitalParam(int list, int index, epicsUInt32 value, epicsUInt32 valueMask, epicsUInt32 interruptMask)
 {
     asynStatus status;
     static const char *functionName = "setUIntDigitalParam";
-    
+
     status = this->params[list]->setUInt32(index, value, valueMask, interruptMask);
     if (status) reportSetParamErrors(status, index, list, functionName);
     return(status);
@@ -1178,8 +1196,8 @@ asynStatus asynPortDriver::setUIntDigitalParam(int list, int index, epicsUInt32 
 
 /** Sets the interrupt mask and reason in the parameter library
   * Calls paramList::setUInt32Interrupt (0, index, mask, reason) i.e. for parameter list 0.
-  * \param[in] index The parameter number 
-  * \param[in] mask Interrupt mask. 
+  * \param[in] index The parameter number
+  * \param[in] mask Interrupt mask.
   * \param[in] reason Interrupt reason. */
 asynStatus asynPortDriver::setUInt32DigitalInterrupt(int index, epicsUInt32 mask, interruptReason reason)
 {
@@ -1189,14 +1207,14 @@ asynStatus asynPortDriver::setUInt32DigitalInterrupt(int index, epicsUInt32 mask
 /** Sets the interrupt mask and reason in the parameter library
   * Calls paramList::setUInt32Interrupt (index, mask, reason) for the parameter list indexed by list.
   * \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
-  * \param[in] index The parameter number 
-  * \param[in] mask Interrupt mask. 
+  * \param[in] index The parameter number
+  * \param[in] mask Interrupt mask.
   * \param[in] reason Interrupt reason. */
 asynStatus asynPortDriver::setUInt32DigitalInterrupt(int list, int index, epicsUInt32 mask, interruptReason reason)
 {
     asynStatus status;
     static const char *functionName = "setUIntDigitalInterrupt";
-    
+
     status = this->params[list]->setUInt32Interrupt(index, mask, reason);
     if (status) reportSetParamErrors(status, index, list, functionName);
     return(status);
@@ -1204,7 +1222,7 @@ asynStatus asynPortDriver::setUInt32DigitalInterrupt(int list, int index, epicsU
 
 /** Clears the interrupt mask in the parameter library
   * Calls paramList::clearUInt32Interrupt (0, index, mask) i.e. for parameter list 0.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[in] mask Interrupt mask. */
 asynStatus asynPortDriver::clearUInt32DigitalInterrupt(int index, epicsUInt32 mask)
 {
@@ -1214,13 +1232,13 @@ asynStatus asynPortDriver::clearUInt32DigitalInterrupt(int index, epicsUInt32 ma
 /** Clears the interrupt mask in the parameter library
   * Calls paramList::clearUInt32Interrupt (index, mask) for the parameter list indexed by list.
   * \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[in] mask Interrupt mask. */
 asynStatus asynPortDriver::clearUInt32DigitalInterrupt(int list, int index, epicsUInt32 mask)
 {
     asynStatus status;
     static const char *functionName = "clearUIntDigitalInterrupt";
-    
+
     status = this->params[list]->clearUInt32Interrupt(index, mask);
     if (status) reportSetParamErrors(status, index, list, functionName);
     return(status);
@@ -1228,8 +1246,8 @@ asynStatus asynPortDriver::clearUInt32DigitalInterrupt(int list, int index, epic
 
 /** Gets the interrupt mask and reason in the parameter library
   * Calls paramList::getUInt32Interrupt (0, index, mask, reason) i.e. for parameter list 0.
-  * \param[in] index The parameter number 
-  * \param[in] mask Interrupt mask. 
+  * \param[in] index The parameter number
+  * \param[in] mask Interrupt mask.
   * \param[in] reason Interrupt reason. */
 asynStatus asynPortDriver::getUInt32DigitalInterrupt(int index, epicsUInt32 *mask, interruptReason reason)
 {
@@ -1239,14 +1257,14 @@ asynStatus asynPortDriver::getUInt32DigitalInterrupt(int index, epicsUInt32 *mas
 /** Gets the interrupt mask and reason in the parameter library
   * Calls paramList::getUInt32Interrupt (index, mask, reason) for the parameter list indexed by list.
   * \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
-  * \param[in] index The parameter number 
-  * \param[in] mask Interrupt mask. 
+  * \param[in] index The parameter number
+  * \param[in] mask Interrupt mask.
   * \param[in] reason Interrupt reason. */
 asynStatus asynPortDriver::getUInt32DigitalInterrupt(int list, int index, epicsUInt32 *mask, interruptReason reason)
 {
     asynStatus status;
     static const char *functionName = "getUIntDigitalInterrupt";
-    
+
     status = this->params[list]->getUInt32Interrupt(index, mask, reason);
     if (status) reportSetParamErrors(status, index, list, functionName);
     return(status);
@@ -1254,7 +1272,7 @@ asynStatus asynPortDriver::getUInt32DigitalInterrupt(int list, int index, epicsU
 
 /** Sets the value for a double in the parameter library.
   * Calls setDoubleParam(0, index, value) i.e. for parameter list 0.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[in] value Value to set. */
 asynStatus asynPortDriver::setDoubleParam(int index, double value)
 {
@@ -1264,13 +1282,13 @@ asynStatus asynPortDriver::setDoubleParam(int index, double value)
 /** Sets the value for a double in the parameter library.
   * Calls paramList::setDouble (index, value) for the parameter list indexed by list.
   * \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[in] value Value to set. */
 asynStatus asynPortDriver::setDoubleParam(int list, int index, double value)
 {
     asynStatus status;
     static const char *functionName = "setDoubleParam";
-    
+
     status = this->params[list]->setDouble(index, value);
     if (status) reportSetParamErrors(status, index, list, functionName);
     return(status);
@@ -1278,7 +1296,7 @@ asynStatus asynPortDriver::setDoubleParam(int list, int index, double value)
 
 /** Sets the value for a string in the parameter library.
   * Calls setStringParam(0, index, value) i.e. for parameter list 0.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[in] value Address of value to set. */
 asynStatus asynPortDriver::setStringParam(int index, const char *value)
 {
@@ -1288,7 +1306,7 @@ asynStatus asynPortDriver::setStringParam(int index, const char *value)
 /** Sets the value for a string in the parameter library.
   * Calls paramList::setString (index, value) for the parameter list indexed by list.
   * \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[in] value Address of value to set. */
 asynStatus asynPortDriver::setStringParam(int list, int index, const char *value)
 {
@@ -1302,7 +1320,7 @@ asynStatus asynPortDriver::setStringParam(int list, int index, const char *value
 
 /** Sets the value for a string in the parameter library.
   * Calls setStringParam(0, index, value) i.e. for parameter list 0.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[in] value String value to set. */
 asynStatus asynPortDriver::setStringParam(int index, const std::string& value)
 {
@@ -1312,7 +1330,7 @@ asynStatus asynPortDriver::setStringParam(int index, const std::string& value)
 /** Sets the value for a string in the parameter library.
   * Calls paramList::setString (index, value) for the parameter list indexed by list.
   * \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[in] value String value to set. */
 asynStatus asynPortDriver::setStringParam(int list, int index, const std::string& value)
 {
@@ -1324,7 +1342,7 @@ asynStatus asynPortDriver::setStringParam(int list, int index, const std::string
     return(status);
 }
 
-/** Reports errors when getting parameters.  
+/** Reports errors when getting parameters.
   * asynParamBadIndex and asynParamWrongType are printed with ASYN_TRACE_ERROR because they should never happen.
   * asynParamUndefined is printed with ASYN_TRACE_FLOW because it is an expected error if the value is read before it
   * is defined, which device support can do.
@@ -1334,7 +1352,7 @@ asynStatus asynPortDriver::setStringParam(int list, int index, const std::string
   * \param[in] functionName The name of the function that generated the error  */
 void asynPortDriver::reportGetParamErrors(asynStatus status, int index, int list, const char *functionName)
 {
-    if (status == asynParamBadIndex) {        
+    if (status == asynParamBadIndex) {
         asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
             "%s:%s: port=%s error getting parameter %d in list %d, bad index\n",
             driverName, functionName, portName, index, list);
@@ -1357,7 +1375,7 @@ void asynPortDriver::reportGetParamErrors(asynStatus status, int index, int list
 
 /** Returns the value for an integer from the parameter library.
   * Calls getIntegerParam(0, index, value) i.e. for parameter list 0.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[out] value Address of value to get. */
 asynStatus asynPortDriver::getIntegerParam(int index, int *value)
 {
@@ -1367,7 +1385,7 @@ asynStatus asynPortDriver::getIntegerParam(int index, int *value)
 /** Returns the value for an integer from the parameter library.
   * Calls paramList::getInteger (index, value) for the parameter list indexed by list.
   * \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[out] value Address of value to get. */
 asynStatus asynPortDriver::getIntegerParam(int list, int index, int *value)
 {
@@ -1381,7 +1399,7 @@ asynStatus asynPortDriver::getIntegerParam(int list, int index, int *value)
 
 /** Returns the value for an UInt32Digital parameter from the parameter library.
   * Calls getUIntDigitalParam(0, index, value, mask) i.e. for parameter list 0.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[out] value Address of value to get.
   * \param[in] mask The mask to apply when getting the value */
 asynStatus asynPortDriver::getUIntDigitalParam(int index, epicsUInt32 *value, epicsUInt32 mask)
@@ -1392,7 +1410,7 @@ asynStatus asynPortDriver::getUIntDigitalParam(int index, epicsUInt32 *value, ep
 /** Returns the value for an UInt32Digital parameter from the parameter library.
   * Calls paramList::getUInt32 (index, value, mask) for the parameter list indexed by list.
   * \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[out] value Address of value to get.
   * \param[in] mask The mask to apply when getting the value. */
 asynStatus asynPortDriver::getUIntDigitalParam(int list, int index, epicsUInt32 *value, epicsUInt32 mask)
@@ -1407,7 +1425,7 @@ asynStatus asynPortDriver::getUIntDigitalParam(int list, int index, epicsUInt32 
 
 /** Returns the value for a double from the parameter library.
   * Calls getDoubleParam(0, index, value) i.e. for parameter list 0.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[out] value Address of value to get. */
 asynStatus asynPortDriver::getDoubleParam(int index, double *value)
 {
@@ -1417,7 +1435,7 @@ asynStatus asynPortDriver::getDoubleParam(int index, double *value)
 /** Returns the value for a double from the parameter library.
   * Calls paramList::getDouble (index, value) for the parameter list indexed by list.
   * \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[out] value Address of value to get. */
 asynStatus asynPortDriver::getDoubleParam(int list, int index, double *value)
 {
@@ -1431,7 +1449,7 @@ asynStatus asynPortDriver::getDoubleParam(int list, int index, double *value)
 
 /** Returns the value for a string from the parameter library.
   * Calls getStringParam(0, index, maxChars, value) i.e. for parameter list 0.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[in] maxChars Maximum number of characters to return.
   * \param[out] value Address of value to get. */
 asynStatus asynPortDriver::getStringParam(int index, int maxChars, char *value)
@@ -1442,7 +1460,7 @@ asynStatus asynPortDriver::getStringParam(int index, int maxChars, char *value)
 /** Returns the value for a string from the parameter library.
   * Calls paramList::getString (index, maxChars, value) for the parameter list indexed by list.
   * \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[in] maxChars Maximum number of characters to return.
   * \param[out] value Address of value to get. */
 asynStatus asynPortDriver::getStringParam(int list, int index, int maxChars, char *value)
@@ -1457,7 +1475,7 @@ asynStatus asynPortDriver::getStringParam(int list, int index, int maxChars, cha
 
 /** Returns the value for a string from the parameter library.
   * Calls getStringParam(0, index, value) i.e. for parameter list 0.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[out] value String value to get. */
 asynStatus asynPortDriver::getStringParam(int index, std::string& value)
 {
@@ -1467,7 +1485,7 @@ asynStatus asynPortDriver::getStringParam(int index, std::string& value)
 /** Returns the value for a string from the parameter library.
   * Calls paramList::getString (index, value) for the parameter list indexed by list.
   * \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
-  * \param[in] index The parameter number 
+  * \param[in] index The parameter number
   * \param[out] value String value to get. */
 asynStatus asynPortDriver::getStringParam(int list, int index, std::string& value)
 {
@@ -1499,14 +1517,14 @@ asynStatus asynPortDriver::callParamCallbacks(int list, int addr)
     return this->params[list]->callCallbacks(addr);
 }
 
-/** Calls paramList::report(fp, details) for each parameter list that the driver supports. 
+/** Calls paramList::report(fp, details) for each parameter list that the driver supports.
   * \param[in] fp The file pointer on which report information will be written
   * \param[in] details The level of report detail desired; always report details on address 0; >=2 report all addresses */
 void asynPortDriver::reportParams(FILE *fp, int details)
 {
     int i;
     int numAddr = 1;
-    
+
     if (details >= 2) numAddr = this->maxAddr;
     for (i=0; i<numAddr; i++) {
         fprintf(fp, "Parameter list %d\n", i);
@@ -1515,24 +1533,24 @@ void asynPortDriver::reportParams(FILE *fp, int details)
 }
 
 
-template <typename epicsType> 
+template <typename epicsType>
 asynStatus readArray(asynUser *pasynUser, epicsType *value, size_t nElements, size_t *nIn)
 {
-    epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize, 
+    epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
                 "%s:readArray not implemented", driverName);
     return(asynError);
 }
 
-template <typename epicsType> 
+template <typename epicsType>
 asynStatus writeArray(asynUser *pasynUser, epicsType *value, size_t nElements)
 {
-    epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize, 
+    epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
                 "%s:writeArray not implemented", driverName);
     return(asynError);
 }
 
 
-template <typename epicsType, typename interruptType> 
+template <typename epicsType, typename interruptType>
 asynStatus asynPortDriver::doCallbacksArray(epicsType *value, size_t nElements,
                                             int reason, int address, void *interruptPvt)
 {
@@ -1572,12 +1590,12 @@ asynStatus asynPortDriver::doCallbacksArray(epicsType *value, size_t nElements,
     return(asynSuccess);
 }
 
-template <typename interruptType> 
+template <typename interruptType>
 void reportInterrupt(FILE *fp, void *interruptPvt, const char *interruptTypeString)
 {
     ELLLIST *pclientList;
     interruptNode *pnode;
-    
+
     if (interruptPvt) {
         pasynManager->interruptStart(interruptPvt, &pclientList);
         pnode = (interruptNode *)ellFirst(pclientList);
@@ -1602,12 +1620,12 @@ void reportInterrupt(FILE *fp, void *interruptPvt, const char *interruptTypeStri
 /** Returns the asyn address associated with a pasynUser structure.
   * Derived classes rarely need to reimplement this function.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
-  * \param[out] address Returned address. 
+  * \param[out] address Returned address.
   * \return Returns asynError if the address is > maxAddr value passed to asynPortDriver::asynPortDriver. */
-asynStatus asynPortDriver::getAddress(asynUser *pasynUser, int *address) 
+asynStatus asynPortDriver::getAddress(asynUser *pasynUser, int *address)
 {
     static const char *functionName = "getAddress";
-    
+
     pasynManager->getAddr(pasynUser, address);
     /* If this is not a multi-device then address is -1, change to 0 */
     if (*address == -1) *address = 0;
@@ -1622,12 +1640,12 @@ asynStatus asynPortDriver::getAddress(asynUser *pasynUser, int *address)
 
 
 /* asynInt32 interface methods */
-extern "C" {static asynStatus readInt32(void *drvPvt, asynUser *pasynUser, 
+extern "C" {static asynStatus readInt32(void *drvPvt, asynUser *pasynUser,
                             epicsInt32 *value)
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->readInt32(pasynUser, value);
     pPvt->unlock();
@@ -1635,7 +1653,7 @@ extern "C" {static asynStatus readInt32(void *drvPvt, asynUser *pasynUser,
 }}
 
 /** Called when asyn clients call pasynInt32->read().
-  * The base class implementation simply returns the value from the parameter library.  
+  * The base class implementation simply returns the value from the parameter library.
   * Derived classes rarely need to reimplement this function.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[out] value Address of the value to read. */
@@ -1648,7 +1666,7 @@ asynStatus asynPortDriver::readInt32(asynUser *pasynUser, epicsInt32 *value)
     asynStatus status = asynSuccess;
     epicsTimeStamp timeStamp; getTimeStamp(&timeStamp);
     static const char *functionName = "readInt32";
-    
+
     status = getAddress(pasynUser, &addr); if (status != asynSuccess) return(status);
     /* We just read the current value of the parameter from the parameter library.
      * Those values are updated whenever anything could cause them to change */
@@ -1657,23 +1675,23 @@ asynStatus asynPortDriver::readInt32(asynUser *pasynUser, epicsInt32 *value)
     pasynUser->timestamp = timeStamp;
     getParamAlarmStatus(addr, function, &pasynUser->alarmStatus);
     getParamAlarmSeverity(addr, function, &pasynUser->alarmSeverity);
-    if (status) 
-        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize, 
-                  "%s:%s: status=%d, function=%d, name=%s, value=%d", 
+    if (status)
+        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
+                  "%s:%s: status=%d, function=%d, name=%s, value=%d",
                   driverName, functionName, status, function, paramName, *value);
-    else        
-        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER, 
-              "%s:%s: function=%d, name=%s, value=%d\n", 
+    else
+        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER,
+              "%s:%s: function=%d, name=%s, value=%d\n",
               driverName, functionName, function, paramName, *value);
     return(status);
 }
 
-extern "C" {static asynStatus writeInt32(void *drvPvt, asynUser *pasynUser, 
+extern "C" {static asynStatus writeInt32(void *drvPvt, asynUser *pasynUser,
                             epicsInt32 value)
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->writeInt32(pasynUser, value);
     pPvt->unlock();
@@ -1681,10 +1699,10 @@ extern "C" {static asynStatus writeInt32(void *drvPvt, asynUser *pasynUser,
 }}
 
 /** Called when asyn clients call pasynInt32->write().
-  * The base class implementation simply sets the value in the parameter library and 
-  * calls any registered callbacks for this pasynUser->reason and address.  
+  * The base class implementation simply sets the value in the parameter library and
+  * calls any registered callbacks for this pasynUser->reason and address.
   * Derived classes will reimplement this function if they need to perform an action when an
-  * asynInt32 value is written. 
+  * asynInt32 value is written.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[in] value Value to write. */
 asynStatus asynPortDriver::writeInt32(asynUser *pasynUser, epicsInt32 value)
@@ -1703,14 +1721,14 @@ asynStatus asynPortDriver::writeInt32(asynUser *pasynUser, epicsInt32 value)
 
     /* Do callbacks so higher layers see any changes */
     status = (asynStatus) callParamCallbacks(addr, addr);
-    
-    if (status) 
-        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize, 
-                  "%s:%s: status=%d, function=%d, name=%s, value=%d", 
+
+    if (status)
+        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
+                  "%s:%s: status=%d, function=%d, name=%s, value=%d",
                   driverName, functionName, status, function, paramName, value);
-    else        
-        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER, 
-              "%s:%s: function=%d, name=%s, value=%d\n", 
+    else
+        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER,
+              "%s:%s: function=%d, name=%s, value=%d\n",
               driverName, functionName, function, paramName, value);
     return status;
 }
@@ -1720,7 +1738,7 @@ extern "C" {static asynStatus getBounds(void *drvPvt, asynUser *pasynUser,
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->getBounds(pasynUser, low, high);
     pPvt->unlock();
@@ -1730,7 +1748,7 @@ extern "C" {static asynStatus getBounds(void *drvPvt, asynUser *pasynUser,
 /** Called when asyn clients call pasynInt32->getBounds(), returning the bounds on the asynInt32 interface
   * for drivers that use raw units.
   * Device support uses these values for unit conversion.
-  * The base class implementation simply returns low=0, high=65535.  
+  * The base class implementation simply returns low=0, high=65535.
   * Derived classes can reimplement this function if they support raw units with different limits.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[out] low Address of the low limit.
@@ -1743,18 +1761,18 @@ asynStatus asynPortDriver::getBounds(asynUser *pasynUser,
     *low = 0;
     *high = 65535;
     asynPrint(pasynUser, ASYN_TRACEIO_DRIVER,
-              "%s::getBounds,low=%d, high=%d\n", 
+              "%s::getBounds,low=%d, high=%d\n",
               driverName, *low, *high);
     return(asynSuccess);
 }
 
 /* asynUInt32Digital interface methods */
-extern "C" {static asynStatus readUInt32Digital(void *drvPvt, asynUser *pasynUser, 
+extern "C" {static asynStatus readUInt32Digital(void *drvPvt, asynUser *pasynUser,
                             epicsUInt32 *value, epicsUInt32 mask)
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->readUInt32Digital(pasynUser, value, mask);
     pPvt->unlock();
@@ -1762,7 +1780,7 @@ extern "C" {static asynStatus readUInt32Digital(void *drvPvt, asynUser *pasynUse
 }}
 
 /** Called when asyn clients call pasynUInt32Digital->read().
-  * The base class implementation simply returns the value from the parameter library.  
+  * The base class implementation simply returns the value from the parameter library.
   * Derived classes rarely need to reimplement this function.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[out] value Address of the value to read.
@@ -1776,7 +1794,7 @@ asynStatus asynPortDriver::readUInt32Digital(asynUser *pasynUser, epicsUInt32 *v
     asynStatus status = asynSuccess;
     epicsTimeStamp timeStamp; getTimeStamp(&timeStamp);
     static const char *functionName = "readUInt32Digital";
-    
+
     status = getAddress(pasynUser, &addr); if (status != asynSuccess) return(status);
     /* We just read the current value of the parameter from the parameter library.
      * Those values are updated whenever anything could cause them to change */
@@ -1785,23 +1803,23 @@ asynStatus asynPortDriver::readUInt32Digital(asynUser *pasynUser, epicsUInt32 *v
     pasynUser->timestamp = timeStamp;
     getParamAlarmStatus(addr, function, &pasynUser->alarmStatus);
     getParamAlarmSeverity(addr, function, &pasynUser->alarmSeverity);
-    if (status) 
-        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize, 
-                  "%s:%s: status=%d, function=%d, name=%s, value=%u mask=%u", 
+    if (status)
+        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
+                  "%s:%s: status=%d, function=%d, name=%s, value=%u mask=%u",
                   driverName, functionName, status, function, paramName, *value, mask);
-    else        
-        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER, 
-              "%s:%s: function=%d, name=%s, value=%u, mask=%u\n", 
+    else
+        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER,
+              "%s:%s: function=%d, name=%s, value=%u, mask=%u\n",
               driverName, functionName, function, paramName, *value, mask);
     return(status);
 }
 
-extern "C" {static asynStatus writeUInt32Digital(void *drvPvt, asynUser *pasynUser, 
+extern "C" {static asynStatus writeUInt32Digital(void *drvPvt, asynUser *pasynUser,
                             epicsUInt32 value, epicsUInt32 mask)
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->writeUInt32Digital(pasynUser, value, mask);
     pPvt->unlock();
@@ -1809,10 +1827,10 @@ extern "C" {static asynStatus writeUInt32Digital(void *drvPvt, asynUser *pasynUs
 }}
 
 /** Called when asyn clients call pasynUInt32Digital->write().
-  * The base class implementation simply sets the value in the parameter library and 
-  * calls any registered callbacks for this pasynUser->reason and address.  
+  * The base class implementation simply sets the value in the parameter library and
+  * calls any registered callbacks for this pasynUser->reason and address.
   * Derived classes will reimplement this function if they need to perform an action when an
-  * asynInt32 value is written. 
+  * asynInt32 value is written.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[in] value Value to write.
   * \param[in] mask Mask value to use when writinging the value. */
@@ -1832,14 +1850,14 @@ asynStatus asynPortDriver::writeUInt32Digital(asynUser *pasynUser, epicsUInt32 v
 
     /* Do callbacks so higher layers see any changes */
     status = (asynStatus) callParamCallbacks(addr, addr);
-    
-    if (status) 
-        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize, 
-                  "%s:%s: status=%d, function=%d, name=%s, value=%u, mask=%u", 
+
+    if (status)
+        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
+                  "%s:%s: status=%d, function=%d, name=%s, value=%u, mask=%u",
                   driverName, functionName, status, function, paramName, value, mask);
-    else        
-        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER, 
-              "%s:%s: function=%d, name=%s, value=%d, mask=%u\n", 
+    else
+        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER,
+              "%s:%s: function=%d, name=%s, value=%d, mask=%u\n",
               driverName, functionName, function, paramName, value, mask);
     return status;
 }
@@ -1848,7 +1866,7 @@ extern "C" {static asynStatus setInterruptUInt32Digital(void *drvPvt, asynUser *
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->setInterruptUInt32Digital(pasynUser, mask, reason);
     pPvt->unlock();
@@ -1856,11 +1874,11 @@ extern "C" {static asynStatus setInterruptUInt32Digital(void *drvPvt, asynUser *
 }}
 
 /** Called when asyn clients call pasynUInt32Digital->setInterrupt().
-  * The base class implementation simply sets the value in the parameter library.  
+  * The base class implementation simply sets the value in the parameter library.
   * Derived classes will reimplement this function if they need to perform an action when an
-  * setInterrupt is called. 
+  * setInterrupt is called.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
-  * \param[in] mask Interrupt mask. 
+  * \param[in] mask Interrupt mask.
   * \param[in] reason Interrupt reason. */
 asynStatus asynPortDriver::setInterruptUInt32Digital(asynUser *pasynUser, epicsUInt32 mask, interruptReason reason)
 {
@@ -1876,13 +1894,13 @@ asynStatus asynPortDriver::setInterruptUInt32Digital(asynUser *pasynUser, epicsU
     /* Set the parameters in the parameter library. */
     status = this->params[addr]->setUInt32Interrupt(function, mask, reason);
 
-    if (status) 
-        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize, 
-                  "%s:%s: status=%d, function=%d, name=%s, mask=%u, reason=%d", 
+    if (status)
+        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
+                  "%s:%s: status=%d, function=%d, name=%s, mask=%u, reason=%d",
                   driverName, functionName, status, function, paramName, mask, reason);
-    else        
-        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER, 
-              "%s:%s: function=%d, name=%s, mask=%u, reason=%d\n", 
+    else
+        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER,
+              "%s:%s: function=%d, name=%s, mask=%u, reason=%d\n",
               driverName, functionName, function, paramName, mask, reason);
     return status;
 }
@@ -1891,7 +1909,7 @@ extern "C" {static asynStatus clearInterruptUInt32Digital(void *drvPvt, asynUser
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->clearInterruptUInt32Digital(pasynUser, mask);
     pPvt->unlock();
@@ -1899,9 +1917,9 @@ extern "C" {static asynStatus clearInterruptUInt32Digital(void *drvPvt, asynUser
 }}
 
 /** Called when asyn clients call pasynUInt32Digital->clearInterrupt().
-  * The base class implementation simply sets the value in the parameter library.  
+  * The base class implementation simply sets the value in the parameter library.
   * Derived classes will reimplement this function if they need to perform an action when an
-  * clearInterrupt is called. 
+  * clearInterrupt is called.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[in] mask Interrupt mask. */
 asynStatus asynPortDriver::clearInterruptUInt32Digital(asynUser *pasynUser, epicsUInt32 mask)
@@ -1918,13 +1936,13 @@ asynStatus asynPortDriver::clearInterruptUInt32Digital(asynUser *pasynUser, epic
     /* Set the parameters in the parameter library. */
     status = this->params[addr]->clearUInt32Interrupt(function, mask);
 
-    if (status) 
-        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize, 
-                  "%s:%s: status=%d, function=%d, name=%s, mask=%u", 
+    if (status)
+        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
+                  "%s:%s: status=%d, function=%d, name=%s, mask=%u",
                   driverName, functionName, status, function, paramName, mask);
-    else        
-        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER, 
-              "%s:%s: function=%d, name=%s, mask=%u\n", 
+    else
+        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER,
+              "%s:%s: function=%d, name=%s, mask=%u\n",
               driverName, functionName, function, paramName, mask);
     return status;
 }
@@ -1933,7 +1951,7 @@ extern "C" {static asynStatus getInterruptUInt32Digital(void *drvPvt, asynUser *
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->getInterruptUInt32Digital(pasynUser, mask, reason);
     pPvt->unlock();
@@ -1941,7 +1959,7 @@ extern "C" {static asynStatus getInterruptUInt32Digital(void *drvPvt, asynUser *
 }}
 
 /** Called when asyn clients call pasynUInt32Digital->getInterrupt().
-  * The base class implementation simply returns the value from the parameter library.  
+  * The base class implementation simply returns the value from the parameter library.
   * Derived classes rarely need to reimplement this function.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[out] mask Interrupt mask address.
@@ -1960,13 +1978,13 @@ asynStatus asynPortDriver::getInterruptUInt32Digital(asynUser *pasynUser, epicsU
     /* Get the parameters in the parameter library. */
     status = this->params[addr]->getUInt32Interrupt(function, mask, reason);
 
-    if (status) 
-        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize, 
-                  "%s:%s: status=%d, function=%d, name=%s, mask=%u, reason=%d", 
+    if (status)
+        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
+                  "%s:%s: status=%d, function=%d, name=%s, mask=%u, reason=%d",
                   driverName, functionName, status, function, paramName, *mask, reason);
-    else        
-        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER, 
-              "%s:%s: function=%d, name=%s, mask=%u, reason=%d\n", 
+    else
+        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER,
+              "%s:%s: function=%d, name=%s, mask=%u, reason=%d\n",
               driverName, functionName, function, paramName, *mask, reason);
     return status;
 }
@@ -1978,7 +1996,7 @@ extern "C" {static asynStatus readFloat64(void *drvPvt, asynUser *pasynUser,
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->readFloat64(pasynUser, value);
     pPvt->unlock();
@@ -1986,7 +2004,7 @@ extern "C" {static asynStatus readFloat64(void *drvPvt, asynUser *pasynUser,
 }}
 
 /** Called when asyn clients call pasynFloat64->read().
-  * The base class implementation simply returns the value from the parameter library.  
+  * The base class implementation simply returns the value from the parameter library.
   * Derived classes rarely need to reimplement this function.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[in] value Address of the value to read. */
@@ -1999,7 +2017,7 @@ asynStatus asynPortDriver::readFloat64(asynUser *pasynUser, epicsFloat64 *value)
     asynStatus status = asynSuccess;
     epicsTimeStamp timeStamp; getTimeStamp(&timeStamp);
     static const char *functionName = "readFloat64";
-    
+
     status = getAddress(pasynUser, &addr); if (status != asynSuccess) return(status);
     /* We just read the current value of the parameter from the parameter library.
      * Those values are updated whenever anything could cause them to change */
@@ -2008,18 +2026,18 @@ asynStatus asynPortDriver::readFloat64(asynUser *pasynUser, epicsFloat64 *value)
     pasynUser->timestamp = timeStamp;
     getParamAlarmStatus(addr, function, &pasynUser->alarmStatus);
     getParamAlarmSeverity(addr, function, &pasynUser->alarmSeverity);
-    if (status == asynParamUndefined) 
-        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize, 
-                  "%s:%s: status=%d, function=%d, name=%s, value is undefined", 
+    if (status == asynParamUndefined)
+        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
+                  "%s:%s: status=%d, function=%d, name=%s, value is undefined",
                   driverName, functionName, status, function, paramName );
-    
-    else if (status) 
-        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize, 
-                  "%s:%s: status=%d, function=%d, name=%s, value=%f", 
+
+    else if (status)
+        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
+                  "%s:%s: status=%d, function=%d, name=%s, value=%f",
                   driverName, functionName, status, function, paramName, *value);
-    else        
-        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER, 
-              "%s:%s: function=%d, name=%s, value=%f\n", 
+    else
+        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER,
+              "%s:%s: function=%d, name=%s, value=%f\n",
               driverName, functionName, function, paramName, *value);
     return(status);
 }
@@ -2029,7 +2047,7 @@ extern "C" {static asynStatus writeFloat64(void *drvPvt, asynUser *pasynUser,
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->writeFloat64(pasynUser, value);
     pPvt->unlock();
@@ -2037,10 +2055,10 @@ extern "C" {static asynStatus writeFloat64(void *drvPvt, asynUser *pasynUser,
 }}
 
 /** Called when asyn clients call pasynFloat64->write().
-  * The base class implementation simply sets the value in the parameter library and 
-  * calls any registered callbacks for this pasynUser->reason and address.  
+  * The base class implementation simply sets the value in the parameter library and
+  * calls any registered callbacks for this pasynUser->reason and address.
   * Derived classes will reimplement this function if they need to perform an action when an
-  * asynFloat64 value is written. 
+  * asynFloat64 value is written.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[in] value Value to write. */
 asynStatus asynPortDriver::writeFloat64(asynUser *pasynUser, epicsFloat64 value)
@@ -2053,19 +2071,19 @@ asynStatus asynPortDriver::writeFloat64(asynUser *pasynUser, epicsFloat64 value)
     static const char *functionName = "writeFloat64";
 
     status = getAddress(pasynUser, &addr); if (status != asynSuccess) return(status);
- 
+
     /* Set the parameter and readback in the parameter library. */
     status = setDoubleParam(addr, function, value);
 
     /* Do callbacks so higher layers see any changes */
     callParamCallbacks(addr, addr);
-    if (status) 
-        asynPrint(pasynUser, ASYN_TRACE_ERROR, 
-              "%s:%s: error, status=%d function=%d, name=%s, value=%f\n", 
+    if (status)
+        asynPrint(pasynUser, ASYN_TRACE_ERROR,
+              "%s:%s: error, status=%d function=%d, name=%s, value=%f\n",
               driverName, functionName, status, function, paramName, value);
-    else        
-        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER, 
-              "%s:%s: function=%d, name=%s, value=%f\n", 
+    else
+        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER,
+              "%s:%s: function=%d, name=%s, value=%f\n",
               driverName, functionName, function, paramName, value);
     return status;
 }
@@ -2079,7 +2097,7 @@ extern "C" {static asynStatus readOctet(void *drvPvt, asynUser *pasynUser,
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->readOctet(pasynUser, value, maxChars, nActual, eomReason);
     pPvt->unlock();
@@ -2087,7 +2105,7 @@ extern "C" {static asynStatus readOctet(void *drvPvt, asynUser *pasynUser,
 }}
 
 /** Called when asyn clients call pasynOctet->read().
-  * The base class implementation simply returns the value from the parameter library.  
+  * The base class implementation simply returns the value from the parameter library.
   * Derived classes rarely need to reimplement this function.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[in] value Address of the string to read.
@@ -2105,7 +2123,7 @@ asynStatus asynPortDriver::readOctet(asynUser *pasynUser,
     asynStatus status = asynSuccess;
     epicsTimeStamp timeStamp; getTimeStamp(&timeStamp);
     static const char *functionName = "readOctet";
-   
+
     status = getAddress(pasynUser, &addr); if (status != asynSuccess) return(status);
     /* We just read the current value of the parameter from the parameter library.
      * Those values are updated whenever anything could cause them to change */
@@ -2114,13 +2132,13 @@ asynStatus asynPortDriver::readOctet(asynUser *pasynUser,
     pasynUser->timestamp = timeStamp;
     getParamAlarmStatus(addr, function, &pasynUser->alarmStatus);
     getParamAlarmSeverity(addr, function, &pasynUser->alarmSeverity);
-    if (status) 
-        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize, 
-                  "%s:%s: status=%d, function=%d, name=%s, value=%s", 
+    if (status)
+        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
+                  "%s:%s: status=%d, function=%d, name=%s, value=%s",
                   driverName, functionName, status, function, paramName, value);
-    else        
-        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER, 
-              "%s:%s: function=%d, name=%s, value=%s\n", 
+    else
+        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER,
+              "%s:%s: function=%d, name=%s, value=%s\n",
               driverName, functionName, function, paramName, value);
     if (eomReason) *eomReason = ASYN_EOM_END;
     *nActual = strlen(value)+1;
@@ -2132,7 +2150,7 @@ extern "C" {static asynStatus writeOctet(void *drvPvt, asynUser *pasynUser,
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->writeOctet(pasynUser, value, maxChars, nActual);
     pPvt->unlock();
@@ -2140,15 +2158,15 @@ extern "C" {static asynStatus writeOctet(void *drvPvt, asynUser *pasynUser,
 }}
 
 /** Called when asyn clients call pasynOctet->write().
-  * The base class implementation simply sets the value in the parameter library and 
-  * calls any registered callbacks for this pasynUser->reason and address.  
+  * The base class implementation simply sets the value in the parameter library and
+  * calls any registered callbacks for this pasynUser->reason and address.
   * Derived classes will reimplement this function if they need to perform an action when an
   * asynOctet value is written.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[in] value Address of the string to write.
   * \param[in] nChars Number of characters to write.
   * \param[out] nActual Number of characters actually written. */
-asynStatus asynPortDriver::writeOctet(asynUser *pasynUser, const char *value, 
+asynStatus asynPortDriver::writeOctet(asynUser *pasynUser, const char *value,
                                     size_t nChars, size_t *nActual)
 {
     int addr=0;
@@ -2166,13 +2184,13 @@ asynStatus asynPortDriver::writeOctet(asynUser *pasynUser, const char *value,
      /* Do callbacks so higher layers see any changes */
     status = (asynStatus)callParamCallbacks(addr, addr);
 
-    if (status) 
-        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize, 
-                  "%s:%s: status=%d, function=%d, name=%s, value=%s", 
+    if (status)
+        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
+                  "%s:%s: status=%d, function=%d, name=%s, value=%s",
                   driverName, functionName, status, function, paramName, value);
-    else        
-        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER, 
-              "%s:%s: function=%d, name=%s, value=%s\n", 
+    else
+        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER,
+              "%s:%s: function=%d, name=%s, value=%s\n",
               driverName, functionName, function, paramName, value);
     *nActual = nChars;
     return status;
@@ -2182,7 +2200,7 @@ extern "C" {static asynStatus flushOctet(void *drvPvt, asynUser *pasynUser)
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->flushOctet(pasynUser);
     pPvt->unlock();
@@ -2192,13 +2210,13 @@ extern "C" {static asynStatus flushOctet(void *drvPvt, asynUser *pasynUser)
 /** Called when asyn clients call pasynOctet->flush().
   * The base class implementation duplicates the function in asynOctetBase.c, i.e.
   * it does reads with a timeout of 0.05 seconds until the underlying driver returns
-  * no more data. 
+  * no more data.
   * Derived classes will reimplement this function if they desire a different behavior.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address. */
 asynStatus asynPortDriver::flushOctet(asynUser *pasynUser)
 {
     double     savetimeout = pasynUser->timeout;
-    char       buffer[100]; 
+    char       buffer[100];
     size_t     nbytesTransfered;
     static const char *functionName = "flushOctet";
 
@@ -2214,12 +2232,12 @@ asynStatus asynPortDriver::flushOctet(asynUser *pasynUser)
     return asynSuccess;
 }
 
-extern "C" {static asynStatus setInputEosOctet(void *drvPvt, asynUser *pasynUser, 
+extern "C" {static asynStatus setInputEosOctet(void *drvPvt, asynUser *pasynUser,
                                 const char *eos, int eosLen)
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->setInputEosOctet(pasynUser, eos, eosLen);
     pPvt->unlock();
@@ -2227,7 +2245,7 @@ extern "C" {static asynStatus setInputEosOctet(void *drvPvt, asynUser *pasynUser
 }}
 
 /** Called when asyn clients call pasynOctet->setInputEos().
-  * The base class implementation simply copies the inputEos to the class private data. 
+  * The base class implementation simply copies the inputEos to the class private data.
   * Derived classes will reimplement this function if they desire a different behavior.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[in] eos The input eos
@@ -2239,14 +2257,14 @@ asynStatus asynPortDriver::setInputEosOctet(asynUser *pasynUser, const char *eos
     strncpy(inputEosOctet, eos, eosLen);
     inputEosLenOctet = eosLen;
     return asynSuccess;
-} 
+}
 
-extern "C" {static asynStatus getInputEosOctet(void *drvPvt, asynUser *pasynUser, 
+extern "C" {static asynStatus getInputEosOctet(void *drvPvt, asynUser *pasynUser,
                                 char *eos, int eosSize, int *eosLen)
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->getInputEosOctet(pasynUser, eos, eosSize, eosLen);
     pPvt->unlock();
@@ -2254,7 +2272,7 @@ extern "C" {static asynStatus getInputEosOctet(void *drvPvt, asynUser *pasynUser
 }}
 
 /** Called when asyn clients call pasynOctet->getInputEos().
-  * The base class implementation simply copies the inputEos from the class private data. 
+  * The base class implementation simply copies the inputEos from the class private data.
   * Derived classes will reimplement this function if they desire a different behavior.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[out] eos The input eos
@@ -2266,14 +2284,14 @@ asynStatus asynPortDriver::getInputEosOctet(asynUser *pasynUser, char *eos, int 
     if (*eosLen > eosSize) *eosLen = eosSize;
     strncpy(eos, inputEosOctet, *eosLen);
     return asynSuccess;
-} 
+}
 
-extern "C" {static asynStatus setOutputEosOctet(void *drvPvt, asynUser *pasynUser, 
+extern "C" {static asynStatus setOutputEosOctet(void *drvPvt, asynUser *pasynUser,
                                 const char *eos, int eosLen)
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->setOutputEosOctet(pasynUser, eos, eosLen);
     pPvt->unlock();
@@ -2281,7 +2299,7 @@ extern "C" {static asynStatus setOutputEosOctet(void *drvPvt, asynUser *pasynUse
 }}
 
 /** Called when asyn clients call pasynOctet->setOutputEos().
-  * The base class implementation simply copies the outputEos to the class private data. 
+  * The base class implementation simply copies the outputEos to the class private data.
   * Derived classes will reimplement this function if they desire a different behavior.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[in] eos The output eos
@@ -2293,14 +2311,14 @@ asynStatus asynPortDriver::setOutputEosOctet(asynUser *pasynUser, const char *eo
     strncpy(outputEosOctet, eos, eosLen);
     outputEosLenOctet = eosLen;
     return asynSuccess;
-} 
+}
 
-extern "C" {static asynStatus getOutputEosOctet(void *drvPvt, asynUser *pasynUser, 
+extern "C" {static asynStatus getOutputEosOctet(void *drvPvt, asynUser *pasynUser,
                                 char *eos, int eosSize, int *eosLen)
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->getOutputEosOctet(pasynUser, eos, eosSize, eosLen);
     pPvt->unlock();
@@ -2308,7 +2326,7 @@ extern "C" {static asynStatus getOutputEosOctet(void *drvPvt, asynUser *pasynUse
 }}
 
 /** Called when asyn clients call pasynOctet->getOutputEos().
-  * The base class implementation simply copies the outputEos from the class private data. 
+  * The base class implementation simply copies the outputEos from the class private data.
   * Derived classes will reimplement this function if they desire a different behavior.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[out] eos The output eos
@@ -2320,7 +2338,7 @@ asynStatus asynPortDriver::getOutputEosOctet(asynUser *pasynUser, char *eos, int
     if (*eosLen > eosSize) *eosLen = eosSize;
     strncpy(eos, outputEosOctet, *eosLen);
     return asynSuccess;
-} 
+}
 
 
 
@@ -2331,7 +2349,7 @@ extern "C" {static asynStatus readInt8Array(void *drvPvt, asynUser *pasynUser, e
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->readInt8Array(pasynUser, value, nElements, nIn);
     pPvt->unlock();
@@ -2339,7 +2357,7 @@ extern "C" {static asynStatus readInt8Array(void *drvPvt, asynUser *pasynUser, e
 }}
 
 /** Called when asyn clients call pasynInt8Array->read().
-  * The base class implementation simply prints an error message.  
+  * The base class implementation simply prints an error message.
   * Derived classes may reimplement this function if required.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[in] value Pointer to the array to read.
@@ -2356,15 +2374,15 @@ extern "C" {static asynStatus writeInt8Array(void *drvPvt, asynUser *pasynUser, 
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->writeInt8Array(pasynUser, value, nElements);
     pPvt->unlock();
-    return(status);    
+    return(status);
 }}
 
 /** Called when asyn clients call pasynInt8Array->write().
-  * The base class implementation simply prints an error message.  
+  * The base class implementation simply prints an error message.
   * Derived classes may reimplement this function if required.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[in] value Pointer to the array to write.
@@ -2394,15 +2412,15 @@ extern "C" {static asynStatus readInt16Array(void *drvPvt, asynUser *pasynUser, 
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->readInt16Array(pasynUser, value, nElements, nIn);
     pPvt->unlock();
-    return(status);    
+    return(status);
 }}
 
 /** Called when asyn clients call pasynInt16Array->read().
-  * The base class implementation simply prints an error message.  
+  * The base class implementation simply prints an error message.
   * Derived classes may reimplement this function if required.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[in] value Pointer to the array to read.
@@ -2419,15 +2437,15 @@ extern "C" {static asynStatus writeInt16Array(void *drvPvt, asynUser *pasynUser,
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->writeInt16Array(pasynUser, value, nElements);
     pPvt->unlock();
-    return(status);    
+    return(status);
 }}
 
 /** Called when asyn clients call pasynInt16Array->write().
-  * The base class implementation simply prints an error message.  
+  * The base class implementation simply prints an error message.
   * Derived classes may reimplement this function if required.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[in] value Pointer to the array to write.
@@ -2457,7 +2475,7 @@ extern "C" {static asynStatus readInt32Array(void *drvPvt, asynUser *pasynUser, 
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-     
+
     pPvt->lock();
     status = pPvt->readInt32Array(pasynUser, value, nElements, nIn);
     pPvt->unlock();
@@ -2465,7 +2483,7 @@ extern "C" {static asynStatus readInt32Array(void *drvPvt, asynUser *pasynUser, 
 }}
 
 /** Called when asyn clients call pasynInt32Array->read().
-  * The base class implementation simply prints an error message.  
+  * The base class implementation simply prints an error message.
   * Derived classes may reimplement this function if required.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[in] value Pointer to the array to read.
@@ -2482,15 +2500,15 @@ extern "C" {static asynStatus writeInt32Array(void *drvPvt, asynUser *pasynUser,
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->writeInt32Array(pasynUser, value, nElements);
     pPvt->unlock();
-    return(status);    
+    return(status);
 }}
 
 /** Called when asyn clients call pasynInt32Array->write().
-  * The base class implementation simply prints an error message.  
+  * The base class implementation simply prints an error message.
   * Derived classes may reimplement this function if required.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[in] value Pointer to the array to write.
@@ -2520,15 +2538,15 @@ extern "C" {static asynStatus readFloat32Array(void *drvPvt, asynUser *pasynUser
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->readFloat32Array(pasynUser, value, nElements, nIn);
     pPvt->unlock();
-    return(status);    
+    return(status);
 }}
 
 /** Called when asyn clients call pasynFloat32Array->read().
-  * The base class implementation simply prints an error message.  
+  * The base class implementation simply prints an error message.
   * Derived classes may reimplement this function if required.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[in] value Pointer to the array to read.
@@ -2545,15 +2563,15 @@ extern "C" {static asynStatus writeFloat32Array(void *drvPvt, asynUser *pasynUse
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->writeFloat32Array(pasynUser, value, nElements);
     pPvt->unlock();
-    return(status);    
+    return(status);
 }}
 
 /** Called when asyn clients call pasynFloat32Array->write().
-  * The base class implementation simply prints an error message.  
+  * The base class implementation simply prints an error message.
   * Derived classes may reimplement this function if required.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[in] value Pointer to the array to write.
@@ -2583,15 +2601,15 @@ extern "C" {static asynStatus readFloat64Array(void *drvPvt, asynUser *pasynUser
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->readFloat64Array(pasynUser, value, nElements, nIn);
     pPvt->unlock();
-    return(status);    
+    return(status);
 }}
 
 /** Called when asyn clients call pasynFloat64Array->read().
-  * The base class implementation simply prints an error message.  
+  * The base class implementation simply prints an error message.
   * Derived classes may reimplement this function if required.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[in] value Pointer to the array to read.
@@ -2608,15 +2626,15 @@ extern "C" {static asynStatus writeFloat64Array(void *drvPvt, asynUser *pasynUse
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->writeFloat64Array(pasynUser, value, nElements);
     pPvt->unlock();
-    return(status);    
+    return(status);
 }}
 
 /** Called when asyn clients call pasynFloat64Array->write().
-  * The base class implementation simply prints an error message.  
+  * The base class implementation simply prints an error message.
   * Derived classes may reimplement this function if required.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[in] value Pointer to the array to write.
@@ -2644,21 +2662,21 @@ extern "C" {static asynStatus readGenericPointer(void *drvPvt, asynUser *pasynUs
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status =pPvt->readGenericPointer(pasynUser, genericPointer);
     pPvt->unlock();
-    return(status);    
+    return(status);
 }}
 
 /** Called when asyn clients call pasynGenericPointer->read().
-  * The base class implementation simply prints an error message.  
+  * The base class implementation simply prints an error message.
   * Derived classes may reimplement this function if required.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[in] genericPointer Pointer to the object to read. */
 asynStatus asynPortDriver::readGenericPointer(asynUser *pasynUser, void *genericPointer)
 {
-    epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize, 
+    epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
                 "%s:readGenericPointer not implemented", driverName);
     return(asynError);
 }
@@ -2667,21 +2685,21 @@ extern "C" {static asynStatus writeGenericPointer(void *drvPvt, asynUser *pasynU
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->writeGenericPointer(pasynUser, genericPointer);
     pPvt->unlock();
-    return(status);    
+    return(status);
 }}
 
 /** Called when asyn clients call pasynGenericPointer->write().
-  * The base class implementation simply prints an error message.  
+  * The base class implementation simply prints an error message.
   * Derived classes may reimplement this function if required.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
   * \param[in] genericPointer Pointer to the object to write. */
 asynStatus asynPortDriver::writeGenericPointer(asynUser *pasynUser, void *genericPointer)
 {
-    epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize, 
+    epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
                 "%s:writeGenericPointer not implemented", driverName);
     return(asynError);
 }
@@ -2735,23 +2753,23 @@ extern "C" {static asynStatus readOption(void *drvPvt, asynUser *pasynUser, cons
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
- 
+
     pPvt->lock();
     status = pPvt->readOption(pasynUser, key, value, maxChars);
     pPvt->unlock();
-    return(status);    
+    return(status);
 }}
 
 /** Called when asyn clients call pasynOption->read().
-  * The base class implementation simply prints an error message.  
+  * The base class implementation simply prints an error message.
   * Derived classes may reimplement this function if required.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
-  * \param[in] key Option key string. 
+  * \param[in] key Option key string.
   * \param[in] value Address of value string to be returned
   * \param[in] maxChars Size of value string */
 asynStatus asynPortDriver::readOption(asynUser *pasynUser, const char *key, char *value, int maxChars)
 {
-    epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize, 
+    epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
                 "%s:readOption not implemented", driverName);
     return(asynError);
 }
@@ -2760,52 +2778,52 @@ extern "C" {static asynStatus writeOption(void *drvPvt, asynUser *pasynUser, con
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->writeOption(pasynUser, key, value);
     pPvt->unlock();
-    return(status);    
+    return(status);
 }}
 
 /** Called when asyn clients call pasynOption->write().
-  * The base class implementation simply prints an error message.  
+  * The base class implementation simply prints an error message.
   * Derived classes may reimplement this function if required.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
-  * \param[in] key Option key string. 
+  * \param[in] key Option key string.
   * \param[in] value Value string. */
 asynStatus asynPortDriver::writeOption(asynUser *pasynUser, const char *key, const char *value)
 {
-    epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize, 
+    epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
                 "%s:writeOption not implemented", driverName);
     return(asynError);
 }
 
 
 /* asynEnums interface methods */
-extern "C" {static asynStatus readEnum(void *drvPvt, asynUser *pasynUser, char *strings[], int values[], int severities[], 
+extern "C" {static asynStatus readEnum(void *drvPvt, asynUser *pasynUser, char *strings[], int values[], int severities[],
                                        size_t nElements, size_t *nIn)
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
- 
+
     pPvt->lock();
     status = pPvt->readEnum(pasynUser, strings, values, severities, nElements, nIn);
     pPvt->unlock();
-    return(status);    
+    return(status);
 }}
 
 /** Called when asyn clients call pasynEnum->read().
-  * The base class implementation simply prints an error message.  
+  * The base class implementation simply prints an error message.
   * Derived classes may reimplement this function if required.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
-  * \param[in] strings Array of string pointers. 
-  * \param[in] values Array of values 
-  * \param[in] severities Array of severities 
-  * \param[in] nElements Size of value array 
+  * \param[in] strings Array of string pointers.
+  * \param[in] values Array of values
+  * \param[in] severities Array of severities
+  * \param[in] nElements Size of value array
   * \param[out] nIn Number of elements actually returned */
 asynStatus asynPortDriver::readEnum(asynUser *pasynUser, char *strings[], int values[], int severities[], size_t nElements, size_t *nIn)
 {
-    epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize, 
+    epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
                 "%s:readEnum not implemented", driverName);
     return(asynError);
 }
@@ -2814,34 +2832,34 @@ extern "C" {static asynStatus writeEnum(void *drvPvt, asynUser *pasynUser, char 
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->writeEnum(pasynUser, strings, values, severities, nElements);
     pPvt->unlock();
-    return(status);    
+    return(status);
 }}
 
 /** Called when asyn clients call pasynEnum->write().
-  * The base class implementation simply prints an error message.  
+  * The base class implementation simply prints an error message.
   * Derived classes may reimplement this function if required.
   * \param[in] pasynUser pasynUser structure that encodes the reason and address.
-  * \param[in] strings Array of string pointers. 
-  * \param[in] values Array of values 
-  * \param[in] severities Array of severities 
+  * \param[in] strings Array of string pointers.
+  * \param[in] values Array of values
+  * \param[in] severities Array of severities
   * \param[in] nElements Size of value array */
 asynStatus asynPortDriver::writeEnum(asynUser *pasynUser, char *strings[], int values[], int severities[], size_t nElements)
 {
-    epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize, 
+    epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
                 "%s:writeEnum not implemented", driverName);
     return(asynError);
 }
 
 
 /** Called by driver to do the callbacks to registered clients on the asynEnum interface.
-  * \param[in] strings Array of string pointers. 
-  * \param[in] values Array of values 
-  * \param[in] severities Array of severities 
-  * \param[in] nElements Size of value array 
+  * \param[in] strings Array of string pointers.
+  * \param[in] values Array of values
+  * \param[in] severities Array of severities
+  * \param[in] nElements Size of value array
   * \param[in] reason A client will be called if reason matches pasynUser->reason registered for that client.
   * \param[in] address A client will be called if address matches the address registered for that client. */
 asynStatus asynPortDriver::doCallbacksEnum(char *strings[], int values[], int severities[], size_t nElements, int reason, int address)
@@ -2872,19 +2890,19 @@ asynStatus asynPortDriver::doCallbacksEnum(char *strings[], int values[], int se
 
 /* asynDrvUser interface methods */
 extern "C" {static asynStatus drvUserCreate(void *drvPvt, asynUser *pasynUser,
-                                 const char *drvInfo, 
+                                 const char *drvInfo,
                                  const char **pptypeName, size_t *psize)
-{ 
+{
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->drvUserCreate(pasynUser, drvInfo, pptypeName, psize);
     pPvt->unlock();
-    return(status);    
+    return(status);
 }}
 
-/** Called by asynManager to pass a pasynUser structure and drvInfo string to the driver; 
+/** Called by asynManager to pass a pasynUser structure and drvInfo string to the driver;
   * Assigns pasynUser->reason based on the value of the drvInfo string.
   * This base class implementation looks up the drvInfo string in the parameter list.
   * \param[in] pasynUser pasynUser structure that driver will modify
@@ -2892,39 +2910,39 @@ extern "C" {static asynStatus drvUserCreate(void *drvPvt, asynUser *pasynUser,
   * \param[out] pptypeName Location in which driver can write information.
   * \param[out] psize Location where driver can write information about size of pptypeName */
 asynStatus asynPortDriver::drvUserCreate(asynUser *pasynUser,
-                                       const char *drvInfo, 
+                                       const char *drvInfo,
                                        const char **pptypeName, size_t *psize)
 {
     static const char *functionName = "drvUserCreate";
     asynStatus status;
     int index;
     int addr;
-    
+
     status = getAddress(pasynUser, &addr); if (status != asynSuccess) return(status);
     status = this->findParam(addr, drvInfo, &index);
     if (status) {
         asynPrint(pasynUser, ASYN_TRACE_ERROR,
-                  "%s:%s: addr=%d, cannot find parameter %s\n", 
+                  "%s:%s: addr=%d, cannot find parameter %s\n",
                   driverName, functionName, addr, drvInfo);
         return(status);
     }
     pasynUser->reason = index;
     asynPrint(pasynUser, ASYN_TRACE_FLOW,
-              "%s:%s: drvInfo=%s, index=%d\n", 
+              "%s:%s: drvInfo=%s, index=%d\n",
               driverName, functionName, drvInfo, index);
     return(asynSuccess);
 }
-    
+
 extern "C" {static asynStatus drvUserGetType(void *drvPvt, asynUser *pasynUser,
                                  const char **pptypeName, size_t *psize)
-{ 
+{
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->drvUserGetType(pasynUser, pptypeName, psize);
     pPvt->unlock();
-    return(status);    
+    return(status);
 }}
 
 /** Returns strings associated with driver-specific commands.
@@ -2949,14 +2967,14 @@ asynStatus asynPortDriver::drvUserGetType(asynUser *pasynUser,
 }
 
 extern "C" {static asynStatus drvUserDestroy(void *drvPvt, asynUser *pasynUser)
-{ 
+{
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->drvUserDestroy(pasynUser);
     pPvt->unlock();
-    return(status);    
+    return(status);
 }}
 
 /** Frees any resources allocated by drvUserCreate.
@@ -2980,7 +2998,7 @@ asynStatus asynPortDriver::drvUserDestroy(asynUser *pasynUser)
 extern "C" {static void report(void *drvPvt, FILE *fp, int details)
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
-    
+
     pPvt->lock();
     pPvt->report(fp, details);
     pPvt->unlock();
@@ -3006,10 +3024,10 @@ void asynPortDriver::report(FILE *fp, int details)
         epicsTimeToStrftime(buff, sizeof(buff), "%Y/%m/%d %H:%M:%S.%03f", &timeStamp);
         fprintf(fp, "  Timestamp: %s\n", buff);
         if (asynStdInterfaces.octet.pinterface) {
-            fprintf(fp, "  Input EOS[%d]: ", this->inputEosLenOctet); 
+            fprintf(fp, "  Input EOS[%d]: ", this->inputEosLenOctet);
             epicsStrPrintEscaped(fp, this->inputEosOctet, this->inputEosLenOctet);
             fprintf(fp, "\n");
-            fprintf(fp, "  Output EOS[%d]: ", this->outputEosLenOctet); 
+            fprintf(fp, "  Output EOS[%d]: ", this->outputEosLenOctet);
             epicsStrPrintEscaped(fp, this->outputEosOctet, this->outputEosLenOctet);
             fprintf(fp, "\n");
         }
@@ -3033,7 +3051,7 @@ void asynPortDriver::report(FILE *fp, int details)
 
 //* Time stamp support functions
 /** Updates the timestamp for this port in pasynManager.
-  * Drivers typically call this function when they receive new data and want 
+  * Drivers typically call this function when they receive new data and want
   * records with TSE=-2 to use this time as their timestamp. */
 asynStatus asynPortDriver::updateTimeStamp()
 {
@@ -3041,8 +3059,8 @@ asynStatus asynPortDriver::updateTimeStamp()
 }
 
 /** Updates the timestamp for this port in pasynManager, and returns this timestamp.
-  * Drivers typically call this function when they receive new data and want 
-  * records with TSE=-2 to use this time as their timestamp. 
+  * Drivers typically call this function when they receive new data and want
+  * records with TSE=-2 to use this time as their timestamp.
   * \param[out] pTimeStamp A pointer to an epicsTimeStamp to receive the new timestamp. */
 asynStatus asynPortDriver::updateTimeStamp(epicsTimeStamp *pTimeStamp)
 {
@@ -3070,14 +3088,14 @@ extern "C" {static asynStatus connect(void *drvPvt, asynUser *pasynUser)
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->connect(pasynUser);
     pPvt->unlock();
-    return(status);    
+    return(status);
 }}
 
-/** Connects driver to device; 
+/** Connects driver to device;
   * The base class implementation simply calls pasynManager->exceptionConnect if address is valid
   * Derived classes can reimplement this function for real connection management.
   * \param[in] pasynUser The pasynUser structure which contains information about the port and address */
@@ -3086,11 +3104,11 @@ asynStatus asynPortDriver::connect(asynUser *pasynUser)
     int addr;
     asynStatus status;
     static const char *functionName = "connect";
-    
+
     status = getAddress(pasynUser, &addr); if (status != asynSuccess) return(status);
     pasynManager->exceptionConnect(pasynUser);
     asynPrint(pasynUser, ASYN_TRACE_FLOW,
-              "%s:%s:, pasynUser=%p\n", 
+              "%s:%s:, pasynUser=%p\n",
               driverName, functionName, pasynUser);
     return(asynSuccess);
 }
@@ -3100,14 +3118,14 @@ extern "C" {static asynStatus disconnect(void *drvPvt, asynUser *pasynUser)
 {
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
-    
+
     pPvt->lock();
     status = pPvt->disconnect(pasynUser);
     pPvt->unlock();
-    return(status);    
+    return(status);
 }}
 
-/** Disconnects driver from device; 
+/** Disconnects driver from device;
   * the base class implementation simply calls pasynManager->exceptionDisconnect.
   * Derived classes can reimplement this function for real connection management.
   * \param[in] pasynUser The pasynUser structure which contains information about the port and address */
@@ -3116,12 +3134,12 @@ asynStatus asynPortDriver::disconnect(asynUser *pasynUser)
     int addr;
     asynStatus status;
     static const char *functionName = "disconnect";
-    
+
     status = getAddress(pasynUser, &addr); if (status != asynSuccess) return(status);
 
     pasynManager->exceptionDisconnect(pasynUser);
     asynPrint(pasynUser, ASYN_TRACE_FLOW,
-              "%s:%s:, pasynUser=%p\n", 
+              "%s:%s:, pasynUser=%p\n",
               driverName, functionName, pasynUser);
     return(asynSuccess);
 }
@@ -3216,8 +3234,8 @@ static asynDrvUser ifaceDrvUser = {
 /** Constructor for the asynPortDriver class.
   * \param[in] portNameIn The name of the asyn port driver to be created.
   * \param[in] maxAddrIn The maximum  number of asyn addr addresses this driver supports.
-               Often it is 1 (which is the minimum), but some drivers, for example a 
-               16-channel D/A or A/D would support values &gt; 1. 
+               Often it is 1 (which is the minimum), but some drivers, for example a
+               16-channel D/A or A/D would support values &gt; 1.
                This controls the number of parameter tables that are created.
   * \param[in] paramTableSize The number of parameters that this driver supports.
                This controls the size of the parameter tables.
@@ -3226,7 +3244,7 @@ static asynDrvUser ifaceDrvUser = {
   * \param[in] interruptMask Bit mask definining the asyn interfaces that can generate interrupts (callbacks).
                The bit mask values are defined in asynPortDriver.h, e.g. asynInt8ArrayMask.
   * \param[in] asynFlags Flags when creating the asyn port driver; includes ASYN_CANBLOCK and ASYN_MULTIDEVICE.
-  * \param[in] autoConnect The autoConnect flag for the asyn port driver. 
+  * \param[in] autoConnect The autoConnect flag for the asyn port driver.
                1 if the driver should autoconnect.
   * \param[in] priority The thread priority for the asyn port driver thread if ASYN_CANBLOCK is set in asynFlags.
                If it is 0 then the default value of epicsThreadPriorityMedium will be assigned by asynManager.
@@ -3245,7 +3263,7 @@ asynPortDriver::asynPortDriver(const char *portNameIn, int maxAddrIn, int paramT
     /* Initialize some members to 0 */
     pInterfaces = &this->asynStdInterfaces;
     memset(pInterfaces, 0, sizeof(asynStdInterfaces));
-        
+
     this->portName = epicsStrDup(portNameIn);
 
     if (maxAddrIn < 1) maxAddrIn = 1;
@@ -3267,7 +3285,7 @@ asynPortDriver::asynPortDriver(const char *portNameIn, int maxAddrIn, int paramT
         printf("%s\n", msg.c_str());
         throw std::runtime_error(msg);
     }
-    
+
     inputEosOctet = epicsStrDup("");
     inputEosLenOctet = 0;
     outputEosOctet = epicsStrDup("");
@@ -3287,14 +3305,14 @@ asynPortDriver::asynPortDriver(const char *portNameIn, int maxAddrIn, int paramT
 
     /* Create asynUser for debugging and for standardInterfacesBase */
     this->pasynUserSelf = pasynManager->createAsynUser(0, 0);
-    
+
     /* The following asynPrint will be governed by the global trace mask since asynUser is not yet connected to port */
     asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW,
         "%s:%s: creating port %s maxAddr=%d, paramTableSize=%d\n"
         "    interfaceMask=0x%X, interruptMask=0x%X\n"
         "    asynFlags=0x%X, autoConnect=%d, priority=%d, stackSize=%d\n",
-        driverName, functionName, this->portName, this->maxAddr, paramTableSize, 
-        interfaceMask, interruptMask, 
+        driverName, functionName, this->portName, this->maxAddr, paramTableSize,
+        interfaceMask, interruptMask,
         asynFlags, autoConnect, priority, stackSize);
 
      /* Set addresses of asyn interfaces */
@@ -3381,7 +3399,7 @@ void* findAsynPortDriver(const char *portName)
     asynUser *pasynUser;
     asynInterface *pasynInterface;
     asynStatus status;
-    
+
     pasynUser = pasynManager->createAsynUser(NULL, NULL);
     status = pasynManager->connectDevice(pasynUser, portName, 0);
     if (status) return NULL;
@@ -3391,5 +3409,5 @@ void* findAsynPortDriver(const char *portName)
     pasynManager->freeAsynUser(pasynUser);
     return pasynInterface->drvPvt;
 }
-    
+
 

--- a/asyn/asynPortDriver/asynPortDriver.h
+++ b/asyn/asynPortDriver/asynPortDriver.h
@@ -45,7 +45,7 @@ public:
     virtual ~asynPortDriver();
     virtual asynStatus lock();
     virtual asynStatus unlock();
-    virtual asynStatus getAddress(asynUser *pasynUser, int *address); 
+    virtual asynStatus getAddress(asynUser *pasynUser, int *address);
     virtual asynStatus readInt32(asynUser *pasynUser, epicsInt32 *value);
     virtual asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);
     virtual asynStatus readUInt32Digital(asynUser *pasynUser, epicsUInt32 *value, epicsUInt32 mask);
@@ -65,7 +65,7 @@ public:
     virtual asynStatus getInputEosOctet(asynUser *pasynUser, char *eos, int eosSize, int *eosLen);
     virtual asynStatus setOutputEosOctet(asynUser *pasynUser, const char *eos, int eosLen);
     virtual asynStatus getOutputEosOctet(asynUser *pasynUser, char *eos, int eosSize, int *eosLen);
-    virtual asynStatus readInt8Array(asynUser *pasynUser, epicsInt8 *value, 
+    virtual asynStatus readInt8Array(asynUser *pasynUser, epicsInt8 *value,
                                         size_t nElements, size_t *nIn);
     virtual asynStatus writeInt8Array(asynUser *pasynUser, epicsInt8 *value,
                                         size_t nElements);
@@ -103,7 +103,7 @@ public:
     virtual asynStatus readEnum(asynUser *pasynUser, char *strings[], int values[], int severities[], size_t nElements, size_t *nIn);
     virtual asynStatus writeEnum(asynUser *pasynUser, char *strings[], int values[], int severities[], size_t nElements);
     virtual asynStatus doCallbacksEnum(char *strings[], int values[], int severities[], size_t nElements, int reason, int addr);
-    virtual asynStatus drvUserCreate(asynUser *pasynUser, const char *drvInfo, 
+    virtual asynStatus drvUserCreate(asynUser *pasynUser, const char *drvInfo,
                                      const char **pptypeName, size_t *psize);
     virtual asynStatus drvUserGetType(asynUser *pasynUser,
                                         const char **pptypeName, size_t *psize);
@@ -111,13 +111,15 @@ public:
     virtual void report(FILE *fp, int details);
     virtual asynStatus connect(asynUser *pasynUser);
     virtual asynStatus disconnect(asynUser *pasynUser);
-   
+
     virtual asynStatus createParam(          const char *name, asynParamType type, int *index);
     virtual asynStatus createParam(int list, const char *name, asynParamType type, int *index);
     virtual asynStatus findParam(          const char *name, int *index);
     virtual asynStatus findParam(int list, const char *name, int *index);
     virtual asynStatus getParamName(          int index, const char **name);
     virtual asynStatus getParamName(int list, int index, const char **name);
+    virtual asynStatus getParamType(          int index, asynParamType *type);
+    virtual asynStatus getParamType(int list, int index, asynParamType *type);
     virtual asynStatus setParamStatus(          int index, asynStatus status);
     virtual asynStatus setParamStatus(int list, int index, asynStatus status);
     virtual asynStatus getParamStatus(          int index, asynStatus *status);
@@ -186,7 +188,7 @@ private:
     int inputEosLenOctet;
     char *outputEosOctet;
     int outputEosLenOctet;
-    template <typename epicsType, typename interruptType> 
+    template <typename epicsType, typename interruptType>
         asynStatus doCallbacksArray(epicsType *value, size_t nElements,
                                     int reason, int address, void *interruptPvt);
 
@@ -194,5 +196,5 @@ private:
 };
 
 #endif /* cplusplus */
-    
+
 #endif


### PR DESCRIPTION
As near as I can tell, there is no (reliable) way to get the asynParamType for a parameter without this function.  Adding this will fill that hole without forcing clients to know things thath might change regarding the internal elements of multiple classes (e.g. the structure of the paramList class, which is not in any header file).