### PR TITLE
fix compile errors on systems where epicsInt32 ==long int

### DIFF
--- a/asyn/asynPortDriver/asynPortDriver.cpp
+++ b/asyn/asynPortDriver/asynPortDriver.cpp
@@ -57,7 +57,7 @@ public:
     asynStatus setDouble(int index, double value);
     asynStatus setString(int index, const char *string);
     asynStatus setString(int index, const std::string& string);
-    asynStatus getInteger(int index, int *value);
+    asynStatus getInteger(int index, epicsInt32 *value);
     asynStatus getUInt32(int index, epicsUInt32 *value, epicsUInt32 mask);
     asynStatus getDouble(int index, double *value);
     asynStatus getString(int index, int maxChars, char *value);
@@ -275,7 +275,7 @@ asynStatus paramList::setString(int index, const std::string& value)
   * \param[out] value Address of value to get.
   * \return Returns asynParamBadIndex if the index is not valid, asynParamWrongType if the parameter type is not asynParamInt32,
   * or asynParamUndefined if the value has not been defined. */
-asynStatus paramList::getInteger(int index, int *value)
+asynStatus paramList::getInteger(int index, epicsInt32 *value)
 {
     asynStatus status;
     *value = 0;
@@ -1359,7 +1359,7 @@ void asynPortDriver::reportGetParamErrors(asynStatus status, int index, int list
   * Calls getIntegerParam(0, index, value) i.e. for parameter list 0.
   * \param[in] index The parameter number 
   * \param[out] value Address of value to get. */
-asynStatus asynPortDriver::getIntegerParam(int index, int *value)
+asynStatus asynPortDriver::getIntegerParam(int index, epicsInt32 *value)
 {
     return this->getIntegerParam(0, index, value);
 }
@@ -1369,7 +1369,7 @@ asynStatus asynPortDriver::getIntegerParam(int index, int *value)
   * \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
   * \param[in] index The parameter number 
   * \param[out] value Address of value to get. */
-asynStatus asynPortDriver::getIntegerParam(int list, int index, int *value)
+asynStatus asynPortDriver::getIntegerParam(int list, int index, epicsInt32 *value)
 {
     asynStatus status;
     static const char *functionName = "getIntegerParam";

--- a/asyn/asynPortDriver/asynPortDriver.h
+++ b/asyn/asynPortDriver/asynPortDriver.h
@@ -150,8 +150,8 @@ public:
     virtual asynStatus setStringParam(int list, int index, const char *value);
     virtual asynStatus setStringParam(          int index, const std::string& value);
     virtual asynStatus setStringParam(int list, int index, const std::string& value);
-    virtual asynStatus getIntegerParam(          int index, int * value);
-    virtual asynStatus getIntegerParam(int list, int index, int * value);
+    virtual asynStatus getIntegerParam(          int index, epicsInt32 * value);
+    virtual asynStatus getIntegerParam(int list, int index, epicsInt32 * value);
     virtual asynStatus getUIntDigitalParam(          int index, epicsUInt32 *value, epicsUInt32 mask);
     virtual asynStatus getUIntDigitalParam(int list, int index, epicsUInt32 *value, epicsUInt32 mask);
     virtual asynStatus getDoubleParam(          int index, double * value);

--- a/asyn/asynPortDriver/paramVal.cpp
+++ b/asyn/asynPortDriver/paramVal.cpp
@@ -125,7 +125,7 @@ bool paramVal::nameEquals(const char* name){
   * \param[in] value Value to set.
   * \throws ParamValWrongType if type is not asynParamInt32
   */
-void paramVal::setInteger(int value)
+void paramVal::setInteger(epicsInt32 value)
 {
     if (type != asynParamInt32)
         throw ParamValWrongType("paramVal::setInteger can only handle asynParamInt32");
@@ -141,7 +141,7 @@ void paramVal::setInteger(int value)
   * \throws ParamValWrongType if type is not asynParamInt32
   * \throws paramValNotDefined if the value is not defined
   */
-int paramVal::getInteger()
+epicsInt32 paramVal::getInteger()
 {
     if (type != asynParamInt32)
         throw ParamValWrongType("paramVal::getInteger can only handle asynParamInt32");

--- a/testArrayRingBufferApp/src/testArrayRingBuffer.cpp
+++ b/testArrayRingBufferApp/src/testArrayRingBuffer.cpp
@@ -129,12 +129,12 @@ testArrayRingBuffer::testArrayRingBuffer(const char *portName, int maxArrayLengt
 void testArrayRingBuffer::arrayGenTask(void)
 {
     double loopDelay;
-    int runStop; 
+    epicsInt32 runStop; 
     int i, j;
-    int burstLength;
+    epicsInt32 burstLength;
     double burstDelay;
-    int maxArrayLength;
-    int arrayLength;
+    epicsInt32 maxArrayLength;
+    epicsInt32 arrayLength;
     
     lock();
     /* Loop forever */ 
@@ -223,7 +223,7 @@ asynStatus testArrayRingBuffer::readInt32Array(asynUser *pasynUser, epicsInt32 *
 {
     int function = pasynUser->reason;
     asynStatus status = asynSuccess;
-    int nCopy;
+    epicsInt32 nCopy;
     const char *functionName = "readFloat64Array";
 
     getIntegerParam(P_ArrayLength, &nCopy);

--- a/testAsynPortDriverApp/src/testAsynPortDriver.cpp
+++ b/testAsynPortDriverApp/src/testAsynPortDriver.cpp
@@ -148,7 +148,7 @@ void testAsynPortDriver::simTask(void)
     double updateTime, minValue, maxValue, meanValue;
     double time, timeStep;
     double noise, yScale;
-    int run, i, maxPoints;
+    epicsInt32 run, i, maxPoints;
     double pi=4.0*atan(1.0);
     
     lock();
@@ -257,7 +257,7 @@ asynStatus testAsynPortDriver::writeFloat64(asynUser *pasynUser, epicsFloat64 va
 {
     int function = pasynUser->reason;
     asynStatus status = asynSuccess;
-    int run;
+    epicsInt32 run;
     const char *paramName;
     const char* functionName = "writeFloat64";
 
@@ -310,7 +310,7 @@ asynStatus testAsynPortDriver::readFloat64Array(asynUser *pasynUser, epicsFloat6
 {
     int function = pasynUser->reason;
     size_t ncopy;
-    int itemp;
+    epicsInt32 itemp;
     asynStatus status = asynSuccess;
     epicsTimeStamp timeStamp;
     const char *functionName = "readFloat64Array";
@@ -361,7 +361,7 @@ asynStatus testAsynPortDriver::readEnum(asynUser *pasynUser, char *strings[], in
 
 void testAsynPortDriver::setVertGain()
 {
-    int igain, i;
+    epicsInt32 igain, i;
     double gain;
     
     getIntegerParam(P_VertGainSelect, &igain);
@@ -377,7 +377,7 @@ void testAsynPortDriver::setVertGain()
 
 void testAsynPortDriver::setVoltsPerDiv()
 {
-    int mVPerDiv;
+    epicsInt32 mVPerDiv;
     
     // Integer volts are in mV
     getIntegerParam(P_VoltsPerDivSelect, &mVPerDiv);
@@ -386,7 +386,7 @@ void testAsynPortDriver::setVoltsPerDiv()
 
 void testAsynPortDriver::setTimePerDiv()
 {
-    int microSecPerDiv;
+    epicsInt32 microSecPerDiv;
     
     // Integer times are in microseconds
     getIntegerParam(P_TimePerDivSelect, &microSecPerDiv);

--- a/testErrorsApp/src/testErrors.cpp
+++ b/testErrorsApp/src/testErrors.cpp
@@ -146,9 +146,9 @@ static void callbackTask(void *drvPvt)
 void testErrors::callbackTask(void)
 {
     asynStatus currentStatus;
-    int alarmStatus;
-    int alarmSeverity;
-    int itemp;
+    epicsInt32 alarmStatus;
+    epicsInt32 alarmSeverity;
+    epicsInt32 itemp;
     epicsInt32 iVal;
     epicsUInt32 uiVal;
     epicsFloat64 dVal;
@@ -260,7 +260,7 @@ void testErrors::callbackTask(void)
 
 void testErrors::setEnums()
 {
-    int order, offset=0, dir=1, i, j;
+    epicsInt32 order, offset=0, dir=1, i, j;
     
     getIntegerParam(P_EnumOrder, &order);
     if (order != 0) {
@@ -299,7 +299,7 @@ asynStatus testErrors::writeInt32(asynUser *pasynUser, epicsInt32 value)
 {
     int function = pasynUser->reason;
     asynStatus status = asynSuccess;
-    int itemp;
+    epicsInt32 itemp;
     const char *paramName;
     const char* functionName = "writeInt32";
 
@@ -345,7 +345,7 @@ asynStatus testErrors::writeFloat64(asynUser *pasynUser, epicsFloat64 value)
 {
     int function = pasynUser->reason;
     asynStatus status = asynSuccess;
-    int itemp;
+    epicsInt32 itemp;
     const char *paramName;
     const char* functionName = "writeFloat64";
 
@@ -382,7 +382,7 @@ asynStatus testErrors::writeUInt32Digital(asynUser *pasynUser, epicsUInt32 value
 {
     int function = pasynUser->reason;
     asynStatus status = asynSuccess;
-    int itemp;
+    epicsInt32 itemp;
     const char *paramName;
     const char* functionName = "writeUInt32D";
 
@@ -423,7 +423,7 @@ asynStatus testErrors::writeOctet(asynUser *pasynUser, const char *value,
 {
     int function = pasynUser->reason;
     asynStatus status = asynSuccess;
-    int itemp;
+    epicsInt32 itemp;
     const char *functionName = "writeOctet";
 
     /* Get the current error status */
@@ -538,7 +538,7 @@ asynStatus testErrors::doReadArray(asynUser *pasynUser, epicsType *value,
 {
     int function = pasynUser->reason;
     size_t ncopy = MAX_ARRAY_POINTS;
-    int status = asynSuccess;
+    epicsInt32 status = asynSuccess;
     epicsTimeStamp timestamp;
     const char *functionName = "doReadArray";
 


### PR DESCRIPTION
Warnings have not been fixed.  On my system long int and int are both 32 bits, but epicsInt32 is mapped to long int instead of int, this causes build errors whenever pointers are referred to with different data types. My changes correct these errors.