### PR TITLE
Fix processing of output records with asyn:READBACK tag on driver callbacks

### DIFF
--- a/asyn/devEpics/devAsynFloat64.c
+++ b/asyn/devEpics/devAsynFloat64.c
@@ -91,6 +91,7 @@ static long createRingBuffer(dbCommon *pr);
 static void processCallbackInput(asynUser *pasynUser);
 static void processCallbackOutput(asynUser *pasynUser);
 static void outputCallbackCallback(CALLBACK *pcb);
+static int  getCallbackValue(devPvt *pPvt);
 static void interruptCallbackInput(void *drvPvt, asynUser *pasynUser,
                 epicsFloat64 value);
 static void interruptCallbackOutput(void *drvPvt, asynUser *pasynUser,
@@ -418,11 +419,14 @@ static void outputCallbackCallback(CALLBACK *pcb)
     callbackGetUser(pPvt, pcb);
     {
         dbCommon *pr = pPvt->pr;
-        struct rset *prset = (struct rset *)pr->rset;
         dbScanLock(pr);
         pPvt->newOutputCallbackValue = 1;
-        (prset->process)(pr);
-        pPvt->newOutputCallbackValue = 0;
+        dbProcess(pr);
+        if (pPvt->newOutputCallbackValue != 0) {
+            /* We called dbProcess but the record did not process, perhaps because PACT was 1 
+             * Need to remove ring buffer element */
+            getCallbackValue(pPvt);
+        }
         dbScanUnlock(pr);
     }
 }
@@ -463,6 +467,7 @@ static int getCallbackValue(devPvt *pPvt)
                                             pPvt->pr->name,pPvt->result.value);
         ret = 1;
     }
+    pPvt->newOutputCallbackValue = 0;
     epicsMutexUnlock(pPvt->ringBufferLock);
     return ret;
 }

--- a/asyn/devEpics/devAsynFloat64.c
+++ b/asyn/devEpics/devAsynFloat64.c
@@ -414,16 +414,17 @@ static void interruptCallbackOutput(void *drvPvt, asynUser *pasynUser,
 
 static void outputCallbackCallback(CALLBACK *pcb)
 {
-    devPvt *pPvt;
+    devPvt *pPvt; 
     callbackGetUser(pPvt, pcb);
-    dbCommon *pr = pPvt->pr;
-    struct rset *prset = (struct rset *)pr->rset;
-
-    dbScanLock(pr);
-    pPvt->newOutputCallbackValue = 1;
-    (prset->process)(pr);
-    pPvt->newOutputCallbackValue = 0;
-    dbScanUnlock(pr);
+    {
+        dbCommon *pr = pPvt->pr;
+        struct rset *prset = (struct rset *)pr->rset;
+        dbScanLock(pr);
+        pPvt->newOutputCallbackValue = 1;
+        (prset->process)(pr);
+        pPvt->newOutputCallbackValue = 0;
+        dbScanUnlock(pr);
+    }
 }
 
 static void interruptCallbackAverage(void *drvPvt, asynUser *pasynUser,

--- a/asyn/devEpics/devAsynInt32.c
+++ b/asyn/devEpics/devAsynInt32.c
@@ -60,9 +60,6 @@
 #define INIT_ERROR -1
 
 #define DEFAULT_RING_BUFFER_SIZE 10
-/* We should be getting these from db_access.h, but get errors including that file? */
-#define MAX_ENUM_STATES 16
-#define MAX_ENUM_STRING_SIZE 26
 
 typedef struct ringBufferElement {
     epicsInt32          value;
@@ -103,9 +100,9 @@ typedef struct devPvt{
     char              *portName;
     char              *userParam;
     int               addr;
-    char              *enumStrings[MAX_ENUM_STATES];
-    int               enumValues[MAX_ENUM_STATES];
-    int               enumSeverities[MAX_ENUM_STATES];
+    char              *enumStrings[DB_MAX_CHOICES];
+    int               enumValues[DB_MAX_CHOICES];
+    int               enumSeverities[DB_MAX_CHOICES];
     asynStatus        previousQueueRequestStatus;
 }devPvt;
 
@@ -415,12 +412,12 @@ static void setEnums(char *outStrings, int *outVals, epicsEnum16 *outSeverities,
     size_t i;
     
     for (i=0; i<numOut; i++) {
-        if (outStrings) outStrings[i*MAX_ENUM_STRING_SIZE] = '\0';
+        if (outStrings) outStrings[i*MAX_STRING_SIZE] = '\0';
         if (outVals) outVals[i] = 0;
         if (outSeverities) outSeverities[i] = 0;
     }
     for (i=0; (i<numIn && i<numOut); i++) {
-        if (outStrings) strncpy(&outStrings[i*MAX_ENUM_STRING_SIZE], inStrings[i], MAX_ENUM_STRING_SIZE);
+        if (outStrings) strncpy(&outStrings[i*MAX_STRING_SIZE], inStrings[i], MAX_STRING_SIZE);
         if (outVals) outVals[i] = inVals[i];
         if (outSeverities) outSeverities[i] = inSeverities[i];
     }
@@ -636,7 +633,7 @@ static void interruptCallbackEnumMbbi(void *drvPvt, asynUser *pasynUser,
     if (!interruptAccept) return;
     dbScanLock((dbCommon*)pr);
     setEnums((char*)&pr->zrst, (int*)&pr->zrvl, &pr->zrsv, 
-             strings, values, severities, nElements, MAX_ENUM_STATES);
+             strings, values, severities, nElements, DB_MAX_CHOICES);
     db_post_events(pr, &pr->val, DBE_PROPERTY);
     dbScanUnlock((dbCommon*)pr);
 }
@@ -650,7 +647,7 @@ static void interruptCallbackEnumMbbo(void *drvPvt, asynUser *pasynUser,
     if (!interruptAccept) return;
     dbScanLock((dbCommon*)pr);
     setEnums((char*)&pr->zrst, (int*)&pr->zrvl, &pr->zrsv, 
-             strings, values, severities, nElements, MAX_ENUM_STATES);
+             strings, values, severities, nElements, DB_MAX_CHOICES);
     db_post_events(pr, &pr->val, DBE_PROPERTY);
     dbScanUnlock((dbCommon*)pr);
 }
@@ -1107,7 +1104,7 @@ static long initMbbi(mbbiRecord *pr)
 
     status = initCommon((dbCommon *)pr,&pr->inp,
         processCallbackInput,interruptCallbackInput, interruptCallbackEnumMbbi,
-        MAX_ENUM_STATES, (char*)&pr->zrst, (int*)&pr->zrvl, &pr->zrsv);
+        DB_MAX_CHOICES, (char*)&pr->zrst, (int*)&pr->zrvl, &pr->zrsv);
     if (status != INIT_OK) return status;
     if(pr->nobt == 0) pr->mask = 0xffffffff;
     pr->mask <<= pr->shft;
@@ -1150,7 +1147,7 @@ static long initMbbo(mbboRecord *pr)
 
     status = initCommon((dbCommon *)pr,&pr->out,
         processCallbackOutput,interruptCallbackOutput, interruptCallbackEnumMbbo,
-        MAX_ENUM_STATES, (char*)&pr->zrst, (int*)&pr->zrvl, &pr->zrsv);
+        DB_MAX_CHOICES, (char*)&pr->zrst, (int*)&pr->zrvl, &pr->zrsv);
     if (status != INIT_OK) return status;
     pPvt = pr->dpvt;
     if(pr->nobt == 0) pr->mask = 0xffffffff;

--- a/asyn/devEpics/devAsynOctet.c
+++ b/asyn/devEpics/devAsynOctet.c
@@ -491,18 +491,18 @@ static void interruptCallback(void *drvPvt, asynUser *pasynUser,
 
 static void outputCallbackCallback(CALLBACK *pcb)
 {
-    devPvt *pPvt;
+    devPvt *pPvt; 
     callbackGetUser(pPvt, pcb);
-    dbCommon *pr = pPvt->precord;
-    struct rset *prset = (struct rset *)pr->rset;
-
-    dbScanLock(pr);
-    pPvt->newOutputCallbackValue = 1;
-    (prset->process)(pr);
-    pPvt->newOutputCallbackValue = 0;
-    dbScanUnlock(pr);
+    {
+        dbCommon *pr = pPvt->precord;
+        struct rset *prset = (struct rset *)pr->rset;
+        dbScanLock(pr);
+        pPvt->newOutputCallbackValue = 1;
+        (prset->process)(pr);
+        pPvt->newOutputCallbackValue = 0;
+        dbScanUnlock(pr);
+    }
 }
-
 
 static int initDrvUser(devPvt *pPvt)
 {

--- a/asyn/devEpics/devAsynOctet.c
+++ b/asyn/devEpics/devAsynOctet.c
@@ -430,7 +430,7 @@ static void interruptCallback(void *drvPvt, asynUser *pasynUser,
 
     asynPrintIO(pPvt->pasynUser, ASYN_TRACEIO_DEVICE,
         (char *)value, len*sizeof(char),
-        "%s %s::interruptCallbackInput ringSize=%d, len=%d, callback data:",
+        "%s %s::interruptCallback ringSize=%d, len=%d, callback data:",
         pr->name, driverName, pPvt->ringSize, (int)len);
     if (len >= pPvt->valSize) len = pPvt->valSize-1;
     if (pPvt->ringSize == 0) {
@@ -448,10 +448,11 @@ static void interruptCallback(void *drvPvt, asynUser *pasynUser,
         pPvt->result.alarmStatus = pasynUser->alarmStatus;
         pPvt->result.alarmSeverity = pasynUser->alarmSeverity;
         dbScanUnlock(pPvt->precord);
-        if (pPvt->isOutput) 
+        if (pPvt->isOutput) {
             callbackRequest(&pPvt->outputCallback);
-        else
+        } else {
             scanIoRequest(pPvt->ioScanPvt);
+        }
     } else {
         /* Using a ring buffer */
         ringBufferElement *rp;

--- a/asyn/devEpics/devAsynUInt32Digital.c
+++ b/asyn/devEpics/devAsynUInt32Digital.c
@@ -506,16 +506,17 @@ static void interruptCallbackOutput(void *drvPvt, asynUser *pasynUser,
 
 static void outputCallbackCallback(CALLBACK *pcb)
 {
-    devPvt *pPvt;
+    devPvt *pPvt; 
     callbackGetUser(pPvt, pcb);
-    dbCommon *pr = pPvt->pr;
-    struct rset *prset = (struct rset *)pr->rset;
-
-    dbScanLock(pr);
-    pPvt->newOutputCallbackValue = 1;
-    (prset->process)(pr);
-    pPvt->newOutputCallbackValue = 0;
-    dbScanUnlock(pr);
+    {
+        dbCommon *pr = pPvt->pr;
+        struct rset *prset = (struct rset *)pr->rset;
+        dbScanLock(pr);
+        pPvt->newOutputCallbackValue = 1;
+        (prset->process)(pr);
+        pPvt->newOutputCallbackValue = 0;
+        dbScanUnlock(pr);
+    }
 }
 
 static void interruptCallbackEnumMbbi(void *drvPvt, asynUser *pasynUser,

--- a/asyn/devEpics/devAsynUInt32Digital.c
+++ b/asyn/devEpics/devAsynUInt32Digital.c
@@ -57,9 +57,6 @@
 #define INIT_ERROR -1
 
 #define DEFAULT_RING_BUFFER_SIZE 10
-/* We should be getting these from db_access.h, but get errors including that file? */
-#define MAX_ENUM_STATES 16
-#define MAX_ENUM_STRING_SIZE 26
 
 typedef struct ringBufferElement {
     epicsUInt32         value;
@@ -94,9 +91,9 @@ typedef struct devPvt{
     char              *portName;
     char              *userParam;
     int               addr;
-    char              *enumStrings[MAX_ENUM_STATES];
-    int               enumValues[MAX_ENUM_STATES];
-    int               enumSeverities[MAX_ENUM_STATES];
+    char              *enumStrings[DB_MAX_CHOICES];
+    int               enumValues[DB_MAX_CHOICES];
+    int               enumSeverities[DB_MAX_CHOICES];
     asynStatus        previousQueueRequestStatus;
 }devPvt;
 
@@ -376,12 +373,12 @@ static void setEnums(char *outStrings, int *outVals, epicsEnum16 *outSeverities,
     size_t i;
     
     for (i=0; i<numOut; i++) {
-        if (outStrings) outStrings[i*MAX_ENUM_STRING_SIZE] = '\0';
+        if (outStrings) outStrings[i*MAX_STRING_SIZE] = '\0';
         if (outVals) outVals[i] = 0;
         if (outSeverities) outSeverities[i] = 0;
     }
     for (i=0; (i<numIn && i<numOut); i++) {
-        if (outStrings) strncpy(&outStrings[i*MAX_ENUM_STRING_SIZE], inStrings[i], MAX_ENUM_STRING_SIZE);
+        if (outStrings) strncpy(&outStrings[i*MAX_STRING_SIZE], inStrings[i], MAX_STRING_SIZE);
         if (outVals) outVals[i] = inVals[i];
         if (outSeverities) outSeverities[i] = inSeverities[i];
     }
@@ -528,7 +525,7 @@ static void interruptCallbackEnumMbbi(void *drvPvt, asynUser *pasynUser,
     if (!interruptAccept) return;
     dbScanLock((dbCommon*)pr);
     setEnums((char*)&pr->zrst, (int*)&pr->zrvl, &pr->zrsv, 
-             strings, values, severities, nElements, MAX_ENUM_STATES);
+             strings, values, severities, nElements, DB_MAX_CHOICES);
     db_post_events(pr, &pr->val, DBE_PROPERTY);
     dbScanUnlock((dbCommon*)pr);
 }
@@ -542,7 +539,7 @@ static void interruptCallbackEnumMbbo(void *drvPvt, asynUser *pasynUser,
     if (!interruptAccept) return;
     dbScanLock((dbCommon*)pr);
     setEnums((char*)&pr->zrst, (int*)&pr->zrvl, &pr->zrsv, 
-             strings, values, severities, nElements, MAX_ENUM_STATES);
+             strings, values, severities, nElements, DB_MAX_CHOICES);
     db_post_events(pr, &pr->val, DBE_PROPERTY);
     dbScanUnlock((dbCommon*)pr);
 }
@@ -822,7 +819,7 @@ static long initMbbi(mbbiRecord *pr)
 
     status = initCommon((dbCommon *)pr,&pr->inp,
         processCallbackInput,interruptCallbackInput, interruptCallbackEnumMbbi,
-        MAX_ENUM_STATES, (char*)&pr->zrst, (int*)&pr->zrvl, &pr->zrsv);
+        DB_MAX_CHOICES, (char*)&pr->zrst, (int*)&pr->zrvl, &pr->zrsv);
     if (status != INIT_OK) return status;
     pPvt = pr->dpvt;
     pr->mask = pPvt->mask;
@@ -866,7 +863,7 @@ static long initMbbo(mbboRecord *pr)
 
     status = initCommon((dbCommon *)pr,&pr->out,
         processCallbackOutput,interruptCallbackOutput, interruptCallbackEnumMbbo,
-        MAX_ENUM_STATES, (char*)&pr->zrst, (int*)&pr->zrvl, &pr->zrsv);
+        DB_MAX_CHOICES, (char*)&pr->zrst, (int*)&pr->zrvl, &pr->zrsv);
     if (status != INIT_OK) return status;
     pPvt = pr->dpvt;
     pr->mask = pPvt->mask;

--- a/asyn/devEpics/devAsynUInt32Digital.c
+++ b/asyn/devEpics/devAsynUInt32Digital.c
@@ -110,6 +110,7 @@ static long getIoIntInfo(int cmd, dbCommon *pr, IOSCANPVT *iopvt);
 static void processCallbackInput(asynUser *pasynUser);
 static void processCallbackOutput(asynUser *pasynUser);
 static void outputCallbackCallback(CALLBACK *pcb);
+static int  getCallbackValue(devPvt *pPvt);
 static void interruptCallbackInput(void *drvPvt, asynUser *pasynUser,
                 epicsUInt32 value);
 static void interruptCallbackOutput(void *drvPvt, asynUser *pasynUser,
@@ -510,11 +511,14 @@ static void outputCallbackCallback(CALLBACK *pcb)
     callbackGetUser(pPvt, pcb);
     {
         dbCommon *pr = pPvt->pr;
-        struct rset *prset = (struct rset *)pr->rset;
         dbScanLock(pr);
         pPvt->newOutputCallbackValue = 1;
-        (prset->process)(pr);
-        pPvt->newOutputCallbackValue = 0;
+        dbProcess(pr);
+        if (pPvt->newOutputCallbackValue != 0) {
+            /* We called dbProcess but the record did not process, perhaps because PACT was 1 
+             * Need to remove ring buffer element */
+            getCallbackValue(pPvt);
+        }
         dbScanUnlock(pr);
     }
 }
@@ -594,6 +598,7 @@ static int getCallbackValue(devPvt *pPvt)
                                             pPvt->pr->name,pPvt->result.value);
         ret = 1;
     }
+    pPvt->newOutputCallbackValue = 0;
     epicsMutexUnlock(pPvt->ringBufferLock);
     return ret;
 }

--- a/asyn/devEpics/devAsynUInt32Digital.c
+++ b/asyn/devEpics/devAsynUInt32Digital.c
@@ -57,6 +57,9 @@
 #define INIT_ERROR -1
 
 #define DEFAULT_RING_BUFFER_SIZE 10
+/* We should be getting these from db_access.h, but get errors including that file? */
+#define MAX_ENUM_STATES 16
+#define MAX_ENUM_STRING_SIZE 26
 
 typedef struct ringBufferElement {
     epicsUInt32         value;
@@ -91,9 +94,9 @@ typedef struct devPvt{
     char              *portName;
     char              *userParam;
     int               addr;
-    char              *enumStrings[DB_MAX_CHOICES];
-    int               enumValues[DB_MAX_CHOICES];
-    int               enumSeverities[DB_MAX_CHOICES];
+    char              *enumStrings[MAX_ENUM_STATES];
+    int               enumValues[MAX_ENUM_STATES];
+    int               enumSeverities[MAX_ENUM_STATES];
     asynStatus        previousQueueRequestStatus;
 }devPvt;
 
@@ -373,12 +376,12 @@ static void setEnums(char *outStrings, int *outVals, epicsEnum16 *outSeverities,
     size_t i;
     
     for (i=0; i<numOut; i++) {
-        if (outStrings) outStrings[i*MAX_STRING_SIZE] = '\0';
+        if (outStrings) outStrings[i*MAX_ENUM_STRING_SIZE] = '\0';
         if (outVals) outVals[i] = 0;
         if (outSeverities) outSeverities[i] = 0;
     }
     for (i=0; (i<numIn && i<numOut); i++) {
-        if (outStrings) strncpy(&outStrings[i*MAX_STRING_SIZE], inStrings[i], MAX_STRING_SIZE);
+        if (outStrings) strncpy(&outStrings[i*MAX_ENUM_STRING_SIZE], inStrings[i], MAX_ENUM_STRING_SIZE);
         if (outVals) outVals[i] = inVals[i];
         if (outSeverities) outSeverities[i] = inSeverities[i];
     }
@@ -525,7 +528,7 @@ static void interruptCallbackEnumMbbi(void *drvPvt, asynUser *pasynUser,
     if (!interruptAccept) return;
     dbScanLock((dbCommon*)pr);
     setEnums((char*)&pr->zrst, (int*)&pr->zrvl, &pr->zrsv, 
-             strings, values, severities, nElements, DB_MAX_CHOICES);
+             strings, values, severities, nElements, MAX_ENUM_STATES);
     db_post_events(pr, &pr->val, DBE_PROPERTY);
     dbScanUnlock((dbCommon*)pr);
 }
@@ -539,7 +542,7 @@ static void interruptCallbackEnumMbbo(void *drvPvt, asynUser *pasynUser,
     if (!interruptAccept) return;
     dbScanLock((dbCommon*)pr);
     setEnums((char*)&pr->zrst, (int*)&pr->zrvl, &pr->zrsv, 
-             strings, values, severities, nElements, DB_MAX_CHOICES);
+             strings, values, severities, nElements, MAX_ENUM_STATES);
     db_post_events(pr, &pr->val, DBE_PROPERTY);
     dbScanUnlock((dbCommon*)pr);
 }
@@ -819,7 +822,7 @@ static long initMbbi(mbbiRecord *pr)
 
     status = initCommon((dbCommon *)pr,&pr->inp,
         processCallbackInput,interruptCallbackInput, interruptCallbackEnumMbbi,
-        DB_MAX_CHOICES, (char*)&pr->zrst, (int*)&pr->zrvl, &pr->zrsv);
+        MAX_ENUM_STATES, (char*)&pr->zrst, (int*)&pr->zrvl, &pr->zrsv);
     if (status != INIT_OK) return status;
     pPvt = pr->dpvt;
     pr->mask = pPvt->mask;
@@ -863,7 +866,7 @@ static long initMbbo(mbboRecord *pr)
 
     status = initCommon((dbCommon *)pr,&pr->out,
         processCallbackOutput,interruptCallbackOutput, interruptCallbackEnumMbbo,
-        DB_MAX_CHOICES, (char*)&pr->zrst, (int*)&pr->zrvl, &pr->zrsv);
+        MAX_ENUM_STATES, (char*)&pr->zrst, (int*)&pr->zrvl, &pr->zrsv);
     if (status != INIT_OK) return status;
     pPvt = pr->dpvt;
     pr->mask = pPvt->mask;

--- a/documentation/RELEASE_NOTES.html
+++ b/documentation/RELEASE_NOTES.html
@@ -14,13 +14,22 @@
     <h2>
       Release 4-33</h2>
     <h2>
-      October XXX, 2017</h2>
+      November XXX, 2017</h2>
   </div>
+  <h3>
+    devAsynInt32.c, devAsynUInt32Digital.c, devAsynFloat64.c, devAsynOctet.c</h3>
+  <ul>
+    <li>Fixed a problem with output records that have the asyn:READBACK info tag, i.e.
+      output records that update on callbacks from the driver. Previously it did not correctly
+      distinguish between record processing due to a driver callback (in which case it
+      should not call the driver) and normal record processing (in which case the driver
+      should be called).</li>
+  </ul>
   <h3>
     devAsynOctet.c</h3>
   <ul>
-    <li>Fixed bug where the record alarm status was not set correctly if a write or read failed
-        with a synchronous driver.</li> 
+    <li>Fixed bug where the record alarm status was not set correctly if a write or read
+      failed with a synchronous driver.</li>
   </ul>
   <div style="text-align: center">
     <hr />


### PR DESCRIPTION
This attempts to fix the race condition identified in #56.  Rather than just using the readback value if the ring buffer has any entries it uses callbackRequest to signal to the process routine that this is a driver callback.  This allows callback processing and normal record processing to be interleaved.

I do have a question about how I implemented this.  In the code @mdavidsaver proposed in #56 he called dbProcess in the callback function.  I am calling the prset->process().  Which is correct?  Can someone explain what happens if the reacback callback occurs while the record is currently in the middle of normal asynchronous processing, i.e. PACT is true waiting for asynchronous completion?
 