### PR TITLE
Add  ASYN_TRACE_USER1,  ASYN_TRACE_USER2

### DIFF
--- a/asyn/asynDriver/asynDriver.h
+++ b/asyn/asynDriver/asynDriver.h
@@ -197,6 +197,7 @@ typedef struct  asynLockPortNotify {
 #define ASYN_TRACEIO_DRIVER  0x0008
 #define ASYN_TRACE_FLOW      0x0010
 #define ASYN_TRACE_WARNING   0x0020
+#define ASYN_TRACE_STATE     0x0040
 
 /* traceIO mask definitions*/
 #define ASYN_TRACEIO_NODATA 0x0000

--- a/asyn/asynRecord/asynRecord.c
+++ b/asyn/asynRecord/asynRecord.c
@@ -188,6 +188,7 @@ typedef struct oldValues {  /* Used in monitor() and monitorStatus() */
     epicsEnum16 tb3;        /* Trace IO driver */
     epicsEnum16 tb4;        /* Trace flow */
     epicsEnum16 tb5;        /* Trace warning */
+    epicsEnum16 tb6;        /* Trace state */
     epicsInt32 tiom;        /* Trace I/O mask */
     epicsEnum16 tib0;       /* Trace IO ASCII */
     epicsEnum16 tib1;       /* Trace IO escape */
@@ -412,12 +413,14 @@ static long special(struct dbAddr * paddr, int after)
     case asynRecordTB3:
     case asynRecordTB4:
     case asynRecordTB5:
+    case asynRecordTB6:
         traceMask = (pasynRec->tb0 ? ASYN_TRACE_ERROR : 0) |
                     (pasynRec->tb1 ? ASYN_TRACEIO_DEVICE : 0) |
                     (pasynRec->tb2 ? ASYN_TRACEIO_FILTER : 0) |
                     (pasynRec->tb3 ? ASYN_TRACEIO_DRIVER : 0) |
                     (pasynRec->tb4 ? ASYN_TRACE_FLOW : 0) |
-                    (pasynRec->tb5 ? ASYN_TRACE_WARNING : 0);
+                    (pasynRec->tb5 ? ASYN_TRACE_WARNING : 0) |
+                    (pasynRec->tb6 ? ASYN_TRACE_STATE : 0);
         pasynTrace->setTraceMask(pasynUser, traceMask);
         return 0;
     case asynRecordTIOM:
@@ -1044,6 +1047,7 @@ static void monitorStatus(asynRecord * pasynRec)
     REMEMBER_STATE(tb3);
     REMEMBER_STATE(tb4);
     REMEMBER_STATE(tb5);
+    REMEMBER_STATE(tb6);
     REMEMBER_STATE(tiom);
     REMEMBER_STATE(tib0);
     REMEMBER_STATE(tib1);
@@ -1066,6 +1070,7 @@ static void monitorStatus(asynRecord * pasynRec)
     pasynRec->tb3 = (traceMask & ASYN_TRACEIO_DRIVER) ? 1 : 0;
     pasynRec->tb4 = (traceMask & ASYN_TRACE_FLOW) ? 1 : 0;
     pasynRec->tb5 = (traceMask & ASYN_TRACE_WARNING) ? 1 : 0;
+    pasynRec->tb6 = (traceMask & ASYN_TRACE_STATE) ? 1 : 0;
     traceMask = pasynTrace->getTraceIOMask(pasynUser);
     pasynRec->tiom = traceMask;
     pasynRec->tib0 = (traceMask & ASYN_TRACEIO_ASCII) ? 1 : 0;
@@ -1101,6 +1106,7 @@ static void monitorStatus(asynRecord * pasynRec)
     POST_IF_NEW(tb3);
     POST_IF_NEW(tb4);
     POST_IF_NEW(tb5);
+    POST_IF_NEW(tb6);
     POST_IF_NEW(tiom);
     POST_IF_NEW(tib0);
     POST_IF_NEW(tib1);

--- a/asyn/asynRecord/asynRecord.dbd
+++ b/asyn/asynRecord/asynRecord.dbd
@@ -520,6 +520,13 @@ recordtype(asyn) {
         interest(1)
         menu(asynTRACE)
     }
+    field(TB6,DBF_MENU) {
+        prompt("Trace state")
+        promptgroup(GUI_DISPLAY)
+        special(SPC_MOD)
+        interest(1)
+        menu(asynTRACE)
+    }
     field(TIOM,DBF_LONG) {
         prompt("Trace I/O mask")
         promptgroup(GUI_DISPLAY)

--- a/documentation/asynRecord.html
+++ b/documentation/asynRecord.html
@@ -1414,6 +1414,12 @@
         <td>
           "Trace warning"</td>
         <td>
+          TB6</td>
+        <td>
+          R/W</td>
+        <td>
+          "Trace state"</td>
+        <td>
           DBF_MENU</td>
         <td>
           The ASYN_TRACE_WARNING bit. Choices are "Off" and "On".</td>
@@ -1557,7 +1563,7 @@
     The above fields are used to control the asynTrace facility. They allow one to turn
     on and off debugging output printed at the shell or written to the trace file.</p>
   <p>
-    The TMSK field allows one to read/write the entire asynTraceMask word. The TB0-TB5
+    The TMSK field allows one to read/write the entire asynTraceMask word. The TB0-TB6
     fields allow one to read/write the individual bits in asynTraceMask. The TIOM field
     allows one to read/write the entire asynTraceIOMask word, and the TIB0-TIB2 fields
     allow one to read/write the individual bits in asynTraceIOMask. The TINM field allows


### PR DESCRIPTION
Sometimes it is useful to have a trace level between WARNING and FLOW
to debug drivers and hardware.
In case of a motor, for example, it will show when the motor starts or
stops, without all the poll() messages.

For a temperatur controller it may be new set points send to the device,
or information when the heater is turned on or off.

Note that these trace bits are highly user and application dependent.
Without the need to change asyn may developers the ASYN_TRACE_USER1
and/or ASYN_TRACE_USER2 to whatever they need.

These bits should be integrated into the different op/ files to be
more useful (but I don't have any of them)