### PR TITLE
devEpics: add ASLO/AOFF/SMOO conversion to ai/ao float64

### DIFF
--- a/asyn/devEpics/devAsynFloat64.c
+++ b/asyn/devEpics/devAsynFloat64.c
@@ -581,7 +581,7 @@ static long initAo(aoRecord *pao)
         /* ASLO/AOFF conversion */
         if (pao->aslo != 0.0) val64 *= pao->aslo;
         val64 += pao->aoff;
-        pao->val = value;
+        pao->val = val64;
         pao->udf = 0;
     }
     pasynFloat64SyncIO->disconnect(pPvt->pasynUserSync);
@@ -595,7 +595,11 @@ static long processAo(aoRecord *pr)
 
     if (pPvt->newOutputCallbackValue && getCallbackValue(pPvt)) {
         if (pPvt->result.status == asynSuccess) {
-            pr->val = pPvt->result.value;
+            epicsFloat64 val64 = pPvt->result.value;
+            /* ASLO/AOFF conversion */
+            if (pr->aslo != 0.0) val64 *= pr->aslo;
+            val64 += pr->aoff;
+            pr->val = val64;
             pr->udf = 0;
         }
     } else if(pr->pact == 0) {

--- a/documentation/RELEASE_NOTES.html
+++ b/documentation/RELEASE_NOTES.html
@@ -17,6 +17,14 @@
       November XXX, 2017</h2>
   </div>
   <h3>
+    devAsynFloat64.c</h3>
+  <ul>
+    <li>Added support for ASLO/AOFF scaling and SMOO value smoothing to the flota64
+      device support for ai and ao records, which directly uses the record's VAL/OVAL
+      fields, so that the record support conversion routines (that use RVAL/VAL)
+      don't work.</li>
+  </ul>
+  <h3>
     devAsynInt32.c, devAsynUInt32Digital.c, devAsynFloat64.c, devAsynOctet.c</h3>
   <ul>
     <li>Fixed a problem with output records that have the asyn:READBACK info tag, i.e.


### PR DESCRIPTION
This is adding ASLO/AOFF conversion (and SMOO handling for ai) to the float64 support for ai/ao records.

Record support code always converts between RVAL (integer) and VAL (double), so it can't be used in cases like this, where the support directly reads/writes the VAL field. This PR adds support for the minimal set of ASLO/AOFF/SMOO conversions. It does not go all the way adding ESLO/EOFF linear and breakpoint table conversions, avoiding excessive code bloat.