### PR TITLE
XON/XOFF flow control setting available in IOC shell

### DIFF
--- a/asyn/miscellaneous/asynInterposeCom.c
+++ b/asyn/miscellaneous/asynInterposeCom.c
@@ -52,7 +52,7 @@
 #define CPO_SET_STOPSIZE         4   /* Comand port option set stop size */
 #define CPO_SET_CONTROL          5   /* Comand port option set control mode */
 # define CPO_CONTROL_NOFLOW        1   /* No flow control */
-# define CPO_CONTROL_XONOFF       2   /* XON/XOFF Flow control*/
+# define CPO_CONTROL_IXON       2   /* XON/XOFF Flow control*/
 # define CPO_CONTROL_HWFLOW        3   /* Hardware flow control */
 #define CPO_SET_LINESTATE_MASK  10 /* Comand port option set linestate mask */
 #define CPO_SET_MODEMSTATE_MASK 11 /* Comand port option set modemstate mask */
@@ -565,7 +565,7 @@ setOption(void *ppvt, asynUser *pasynUser, const char *key, const char *val)
     }
     else if (epicsStrCaseCmp(key, "crtscts") == 0) {
         xBuf[0] = CPO_SET_CONTROL;
-        if (pinterposePvt->flow == CPO_CONTROL_XONOFF){
+        if (pinterposePvt->flow == CPO_CONTROL_IXON){
             epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
                             "XON/XOFF already set. Now using RTS/CTS.");
         }
@@ -579,14 +579,14 @@ setOption(void *ppvt, asynUser *pasynUser, const char *key, const char *val)
         status = sbComPortOption(pinterposePvt, pasynUser, xBuf, 2, rBuf);
         if (status == asynSuccess) pinterposePvt->flow = rBuf[0] & 0xFF;
     }
-    else if (epicsStrCaseCmp(key, "xonoff") == 0){
+    else if (epicsStrCaseCmp(key, "ixon") == 0){
         xBuf[0] = CPO_SET_CONTROL;
         if (pinterposePvt->flow == CPO_CONTROL_HWFLOW){
             epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
                              "RTS/CTS already set. Now using XON/XOFF.");
         }
         if      (epicsStrCaseCmp(val, "n") == 0) xBuf[1] = pinterposePvt->flow;
-        else if (epicsStrCaseCmp(val, "y") == 0) xBuf[1] = CPO_CONTROL_XONOFF;
+        else if (epicsStrCaseCmp(val, "y") == 0) xBuf[1] = CPO_CONTROL_IXON;
         else {
             epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
                                                                   "Bad option value");
@@ -640,7 +640,7 @@ getOption(void *ppvt, asynUser *pasynUser, const char *key, char *val, int valSi
     else if (epicsStrCaseCmp(key, "crtscts") == 0) {
         switch (pinterposePvt->flow) {
         case CPO_CONTROL_NOFLOW:  l = epicsSnprintf(val, valSize, "N");  break;
-        case CPO_CONTROL_XONOFF: l = epicsSnprintf(val, valSize, "N");  break;
+        case CPO_CONTROL_IXON: l = epicsSnprintf(val, valSize, "N");  break;
         case CPO_CONTROL_HWFLOW:  l = epicsSnprintf(val, valSize, "Y");  break;
         default:
             epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
@@ -648,10 +648,10 @@ getOption(void *ppvt, asynUser *pasynUser, const char *key, char *val, int valSi
             return asynError;
         }
     }
-    else if (epicsStrCaseCmp(key, "xonoff") == 0) {
+    else if (epicsStrCaseCmp(key, "ixon") == 0) {
         switch (pinterposePvt->flow) {
         case CPO_CONTROL_NOFLOW:  l = epicsSnprintf(val, valSize, "N");  break;
-        case CPO_CONTROL_XONOFF: l = epicsSnprintf(val, valSize, "Y");  break;
+        case CPO_CONTROL_IXON: l = epicsSnprintf(val, valSize, "Y");  break;
         case CPO_CONTROL_HWFLOW:  l = epicsSnprintf(val, valSize, "N");  break;
         default:
             epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
@@ -684,7 +684,7 @@ restoreSettings(interposePvt *pinterposePvt, asynUser *pasynUser)
 { 
     asynStatus s;
     int i;
-    const char *keys[] = { "baud", "bits", "parity", "stop", "crtscts", "xonoff" };
+    const char *keys[] = { "baud", "bits", "parity", "stop", "crtscts", "ixon" };
     char val[20];
     char xBuf[2], rBuf[1];
 

--- a/asyn/miscellaneous/asynInterposeCom.c
+++ b/asyn/miscellaneous/asynInterposeCom.c
@@ -52,6 +52,7 @@
 #define CPO_SET_STOPSIZE         4   /* Comand port option set stop size */
 #define CPO_SET_CONTROL          5   /* Comand port option set control mode */
 # define CPO_CONTROL_NOFLOW        1   /* No flow control */
+# define CPO_CONTROL_XONXOFF       2   /* XON/XOFF Flow control*/
 # define CPO_CONTROL_HWFLOW        3   /* Hardware flow control */
 #define CPO_SET_LINESTATE_MASK  10 /* Comand port option set linestate mask */
 #define CPO_SET_MODEMSTATE_MASK 11 /* Comand port option set modemstate mask */
@@ -564,7 +565,11 @@ setOption(void *ppvt, asynUser *pasynUser, const char *key, const char *val)
     }
     else if (epicsStrCaseCmp(key, "crtscts") == 0) {
         xBuf[0] = CPO_SET_CONTROL;
-        if      (epicsStrCaseCmp(val, "n") == 0) xBuf[1] = CPO_CONTROL_NOFLOW;
+        if (pinterposePvt->flow == CPO_CONTROL_XONXOFF){
+            epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
+                            "XON/XOFF already set. Now using RTS/CTS.");
+        }
+        if      (epicsStrCaseCmp(val, "n") == 0) xBuf[1] = pinterposePvt->flow;
         else if (epicsStrCaseCmp(val, "y") == 0) xBuf[1] = CPO_CONTROL_HWFLOW;
         else {
             epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
@@ -573,6 +578,26 @@ setOption(void *ppvt, asynUser *pasynUser, const char *key, const char *val)
         }
         status = sbComPortOption(pinterposePvt, pasynUser, xBuf, 2, rBuf);
         if (status == asynSuccess) pinterposePvt->flow = rBuf[0] & 0xFF;
+    }
+    else if (epicsStrCaseCmp(key, "cxonxoff") == 0){
+        xBuf[0] = CPO_SET_CONTROL;
+        if (pinterposePvt->flow == CPO_CONTROL_HWFLOW){
+            epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
+                             "RTS/CTS already set. Now using XON/XOFF.");
+        }
+        if      (epicsStrCaseCmp(val, "n") == 0) xBuf[1] = pinterposePvt->flow;
+        else if (epicsStrCaseCmp(val, "y") == 0) xBuf[1] = CPO_CONTROL_XONXOFF;
+        else {
+            epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
+                                                                  "Bad option value");
+        }
+        status = sbComPortOption(pinterposePvt, pasynUser, xBuf, 2, rBuf);
+        if (status == asynSuccess) {
+           pinterposePvt->flow = rBuf[0] & 0xFF;
+        }
+        else{
+           printf("XON/XOFF not set.\n");
+        }
     }
     else {
         if (pinterposePvt->pasynOptionDrv) {
@@ -614,8 +639,20 @@ getOption(void *ppvt, asynUser *pasynUser, const char *key, char *val, int valSi
     }
     else if (epicsStrCaseCmp(key, "crtscts") == 0) {
         switch (pinterposePvt->flow) {
-        case CPO_CONTROL_NOFLOW: l = epicsSnprintf(val, valSize, "N");  break;
-        case CPO_CONTROL_HWFLOW: l = epicsSnprintf(val, valSize, "Y");  break;
+        case CPO_CONTROL_NOFLOW:  l = epicsSnprintf(val, valSize, "N");  break;
+        case CPO_CONTROL_XONXOFF: l = epicsSnprintf(val, valSize, "N");  break;
+        case CPO_CONTROL_HWFLOW:  l = epicsSnprintf(val, valSize, "Y");  break;
+        default:
+            epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
+                          "Unknown flow control code %#X", pinterposePvt->flow);
+            return asynError;
+        }
+    }
+    else if (epicsStrCaseCmp(key, "cxonxoff") == 0) {
+        switch (pinterposePvt->flow) {
+        case CPO_CONTROL_NOFLOW:  l = epicsSnprintf(val, valSize, "N");  break;
+        case CPO_CONTROL_XONXOFF: l = epicsSnprintf(val, valSize, "Y");  break;
+        case CPO_CONTROL_HWFLOW:  l = epicsSnprintf(val, valSize, "N");  break;
         default:
             epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
                           "Unknown flow control code %#X", pinterposePvt->flow);
@@ -647,7 +684,7 @@ restoreSettings(interposePvt *pinterposePvt, asynUser *pasynUser)
 { 
     asynStatus s;
     int i;
-    const char *keys[] = { "baud", "bits", "parity", "stop", "crtscts" };
+    const char *keys[] = { "baud", "bits", "parity", "stop", "crtscts", "cxonxoff" };
     char val[20];
     char xBuf[2], rBuf[1];
 

--- a/asyn/miscellaneous/asynInterposeCom.c
+++ b/asyn/miscellaneous/asynInterposeCom.c
@@ -52,7 +52,7 @@
 #define CPO_SET_STOPSIZE         4   /* Comand port option set stop size */
 #define CPO_SET_CONTROL          5   /* Comand port option set control mode */
 # define CPO_CONTROL_NOFLOW        1   /* No flow control */
-# define CPO_CONTROL_XONXOFF       2   /* XON/XOFF Flow control*/
+# define CPO_CONTROL_XONOFF       2   /* XON/XOFF Flow control*/
 # define CPO_CONTROL_HWFLOW        3   /* Hardware flow control */
 #define CPO_SET_LINESTATE_MASK  10 /* Comand port option set linestate mask */
 #define CPO_SET_MODEMSTATE_MASK 11 /* Comand port option set modemstate mask */
@@ -565,7 +565,7 @@ setOption(void *ppvt, asynUser *pasynUser, const char *key, const char *val)
     }
     else if (epicsStrCaseCmp(key, "crtscts") == 0) {
         xBuf[0] = CPO_SET_CONTROL;
-        if (pinterposePvt->flow == CPO_CONTROL_XONXOFF){
+        if (pinterposePvt->flow == CPO_CONTROL_XONOFF){
             epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
                             "XON/XOFF already set. Now using RTS/CTS.");
         }
@@ -579,14 +579,14 @@ setOption(void *ppvt, asynUser *pasynUser, const char *key, const char *val)
         status = sbComPortOption(pinterposePvt, pasynUser, xBuf, 2, rBuf);
         if (status == asynSuccess) pinterposePvt->flow = rBuf[0] & 0xFF;
     }
-    else if (epicsStrCaseCmp(key, "cxonxoff") == 0){
+    else if (epicsStrCaseCmp(key, "xonoff") == 0){
         xBuf[0] = CPO_SET_CONTROL;
         if (pinterposePvt->flow == CPO_CONTROL_HWFLOW){
             epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
                              "RTS/CTS already set. Now using XON/XOFF.");
         }
         if      (epicsStrCaseCmp(val, "n") == 0) xBuf[1] = pinterposePvt->flow;
-        else if (epicsStrCaseCmp(val, "y") == 0) xBuf[1] = CPO_CONTROL_XONXOFF;
+        else if (epicsStrCaseCmp(val, "y") == 0) xBuf[1] = CPO_CONTROL_XONOFF;
         else {
             epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
                                                                   "Bad option value");
@@ -640,7 +640,7 @@ getOption(void *ppvt, asynUser *pasynUser, const char *key, char *val, int valSi
     else if (epicsStrCaseCmp(key, "crtscts") == 0) {
         switch (pinterposePvt->flow) {
         case CPO_CONTROL_NOFLOW:  l = epicsSnprintf(val, valSize, "N");  break;
-        case CPO_CONTROL_XONXOFF: l = epicsSnprintf(val, valSize, "N");  break;
+        case CPO_CONTROL_XONOFF: l = epicsSnprintf(val, valSize, "N");  break;
         case CPO_CONTROL_HWFLOW:  l = epicsSnprintf(val, valSize, "Y");  break;
         default:
             epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
@@ -648,10 +648,10 @@ getOption(void *ppvt, asynUser *pasynUser, const char *key, char *val, int valSi
             return asynError;
         }
     }
-    else if (epicsStrCaseCmp(key, "cxonxoff") == 0) {
+    else if (epicsStrCaseCmp(key, "xonoff") == 0) {
         switch (pinterposePvt->flow) {
         case CPO_CONTROL_NOFLOW:  l = epicsSnprintf(val, valSize, "N");  break;
-        case CPO_CONTROL_XONXOFF: l = epicsSnprintf(val, valSize, "Y");  break;
+        case CPO_CONTROL_XONOFF: l = epicsSnprintf(val, valSize, "Y");  break;
         case CPO_CONTROL_HWFLOW:  l = epicsSnprintf(val, valSize, "N");  break;
         default:
             epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize,
@@ -684,7 +684,7 @@ restoreSettings(interposePvt *pinterposePvt, asynUser *pasynUser)
 { 
     asynStatus s;
     int i;
-    const char *keys[] = { "baud", "bits", "parity", "stop", "crtscts", "cxonxoff" };
+    const char *keys[] = { "baud", "bits", "parity", "stop", "crtscts", "xonoff" };
     char val[20];
     char xBuf[2], rBuf[1];
 

--- a/documentation/asynDriver.html
+++ b/documentation/asynDriver.html
@@ -5375,7 +5375,9 @@ struct asynGpibPort {
     crtscts=N and clocal=N implies crtscts=Y.</p>
   <p>
     ixon controls XON/OFF flow control on output. If the IOC receives an XOFF character,
-    it suspends output until an XON character is received.</p>
+    it suspends output until an XON character is received. This option is also supported
+    on ports communicating via the RFC 2217 Telnet protocol. In this case, as noted in the
+    standard, ixon implies both outbound and inbound flow control.</p>
   <p>
     ixoff controls XON/OFF flow control on input. The IOC sends XOFF and XON characters
     as necessary to prevent input from coming in faster than programs are reading it.


### PR DESCRIPTION
We needed this functionality for use with a Rubidium frequency standard. It works if specified in the IOC shell, but I have not yet implemented it as a setting in the asyn record.