### PR TITLE
Fix build on arch linux.

### DIFF
--- a/asyn/Makefile
+++ b/asyn/Makefile
@@ -13,8 +13,6 @@ include $(TOP)/configure/CONFIG
 ASYN = $(TOP)/asyn
 #USR_CFLAGS += -DDEBUG
 USR_INCLUDES_cygwin32 += -I/usr/include/tirpc
-USR_INCLUDES_Linux += -I/usr/include/tirpc
-asyn_SYS_LIBS_Linux += tirpc
 
 # The following gets rid of the -fno-implicit-templates flag on vxWorks, 
 # so we get automatic template instantiation.
@@ -32,6 +30,13 @@ else
 endif
 asyn_SYS_LIBS_WIN32 = ws2_32 winmm
 asyn_SYS_LIBS_cygwin32 = $(CYGWIN_RPC_LIB)
+
+# Some linux systems moved RPC related symbols to libtirpc
+# Define TIRPC in configure/CONFIG_SITE in this case
+ifeq ($(TIRPC),YES)
+  USR_INCLUDES_Linux += -I/usr/include/tirpc
+  asyn_SYS_LIBS_Linux += tirpc
+endif
 
 SRC_DIRS += $(ASYN)/asynDriver
 INC += asynDriver.h

--- a/asyn/Makefile
+++ b/asyn/Makefile
@@ -13,6 +13,8 @@ include $(TOP)/configure/CONFIG
 ASYN = $(TOP)/asyn
 #USR_CFLAGS += -DDEBUG
 USR_INCLUDES_cygwin32 += -I/usr/include/tirpc
+USR_INCLUDES_Linux += -I/usr/include/tirpc
+asyn_SYS_LIBS_Linux += tirpc
 
 # The following gets rid of the -fno-implicit-templates flag on vxWorks, 
 # so we get automatic template instantiation.

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -48,5 +48,9 @@ LINUX_GPIB=NO
 # If you want to build asyn so the only dependency on EPICS base is libCom then set the following flag
 #EPICS_LIBCOM_ONLY=YES
 
+# Some linux systems moved RPC related symbols to libtirpc
+# To enable linking against this library, uncomment the following line
+# TIRPC=YES
+
 -include $(SUPPORT)/configure/CONFIG_SITE
 


### PR DESCRIPTION
Arch linux has moved rpc related symbols to libtirpc. The additional package rpcsvc-proto is needed. In addition, asyn needs to set the include path and linked libraries accordingly.

