### PR TITLE
Fix output callback

### DIFF
--- a/asyn/devEpics/devAsynFloat64.c
+++ b/asyn/devEpics/devAsynFloat64.c
@@ -67,7 +67,7 @@ typedef struct devPvt{
     void              *float64Pvt;
     void              *registrarPvt;
     int               canBlock;
-    epicsMutexId      ringBufferLock;
+    epicsMutexId      devPvtLock;
     ringBufferElement *ringBuffer;
     int               ringHead;
     int               ringTail;
@@ -79,6 +79,7 @@ typedef struct devPvt{
     int               numAverage;
     int               isAiAverage;
     int               isIOIntrScan;
+    int               asyncProcessingActive;
     CALLBACK          processCallback;
     CALLBACK          outputCallback;
     int               newOutputCallbackValue;
@@ -149,7 +150,7 @@ static long initCommon(dbCommon *pr, DBLINK *plink,
     pasynUser = pasynManager->createAsynUser(processCallback, 0);
     pasynUser->userPvt = pPvt;
     pPvt->pasynUser = pasynUser;
-    pPvt->ringBufferLock = epicsMutexCreate();
+    pPvt->devPvtLock = epicsMutexCreate();
     /* Parse the link to get addr and port */
     status = pasynEpicsUtils->parseLink(pasynUser, plink,
                 &pPvt->portName, &pPvt->addr,&pPvt->userParam);
@@ -384,7 +385,7 @@ static void interruptCallbackInput(void *drvPvt, asynUser *pasynUser,
      * Instead we just return.  There will then be nothing in the ring buffer, so the first
      * read will do a read from the driver, which should be OK. */
     if (!interruptAccept) return;
-    epicsMutexLock(pPvt->ringBufferLock);
+    epicsMutexLock(pPvt->devPvtLock);
     rp = &pPvt->ringBuffer[pPvt->ringHead];
     rp->value = value;
     rp->time = pasynUser->timestamp;
@@ -404,7 +405,7 @@ static void interruptCallbackInput(void *drvPvt, asynUser *pasynUser,
          * element to the ring buffer, not if we just replaced an element. */
         scanIoRequest(pPvt->ioScanPvt);
     }
-    epicsMutexUnlock(pPvt->ringBufferLock);
+    epicsMutexUnlock(pPvt->devPvtLock);
 }
 
 static void interruptCallbackOutput(void *drvPvt, asynUser *pasynUser,
@@ -419,8 +420,7 @@ static void interruptCallbackOutput(void *drvPvt, asynUser *pasynUser,
         "%s %s::%s new value=%f\n",
         pr->name, driverName, functionName,value);
     if (!interruptAccept) return;
-    dbScanLock(pr);
-    epicsMutexLock(pPvt->ringBufferLock);
+    epicsMutexLock(pPvt->devPvtLock);
     rp = &pPvt->ringBuffer[pPvt->ringHead];
     rp->value = value;
     rp->time = pasynUser->timestamp;
@@ -432,16 +432,15 @@ static void interruptCallbackOutput(void *drvPvt, asynUser *pasynUser,
         pPvt->ringTail = (pPvt->ringTail==pPvt->ringSize) ? 0 : pPvt->ringTail+1;
         pPvt->ringBufferOverflows++;
     } else {
-        /* If PACT is true then this callback was received during asynchronous record processing
-         * Must defer calling callbackRequest until end of record processing */
-        if (pr->pact) {
+        /* If this callback was received during asynchronous record processing
+         * we must defer calling callbackRequest until end of record processing */
+        if (pPvt->asyncProcessingActive) {
             pPvt->numDeferredOutputCallbacks++;
         } else { 
             callbackRequest(&pPvt->outputCallback);
         }
     }
-    epicsMutexUnlock(pPvt->ringBufferLock);
-    dbScanUnlock(pr);
+    epicsMutexUnlock(pPvt->devPvtLock);
 }
 
 static void outputCallbackCallback(CALLBACK *pcb)
@@ -453,6 +452,7 @@ static void outputCallbackCallback(CALLBACK *pcb)
     {
         dbCommon *pr = pPvt->pr;
         dbScanLock(pr);
+        epicsMutexLock(pPvt->devPvtLock);
         pPvt->newOutputCallbackValue = 1;
         dbProcess(pr);
         if (pPvt->newOutputCallbackValue != 0) {
@@ -464,6 +464,7 @@ static void outputCallbackCallback(CALLBACK *pcb)
             getCallbackValue(pPvt);
             pPvt->newOutputCallbackValue = 0;
         }
+        epicsMutexUnlock(pPvt->devPvtLock);
         dbScanUnlock(pr);
     }
 }
@@ -482,7 +483,7 @@ static void interruptCallbackAverage(void *drvPvt, asynUser *pasynUser,
         "%s %s::%s new value=%f\n",
         pr->name, driverName, functionName,value);
     if (!interruptAccept) return;
-    epicsMutexLock(pPvt->ringBufferLock);
+    epicsMutexLock(pPvt->devPvtLock);
     pPvt->numAverage++;
     pPvt->sum += value;
     /* We use the SVAL field to hold the number of values to average when SCAN=I/O Intr
@@ -524,7 +525,7 @@ static void interruptCallbackAverage(void *drvPvt, asynUser *pasynUser,
         pPvt->result.alarmStatus = pasynUser->alarmStatus;
         pPvt->result.alarmSeverity = pasynUser->alarmSeverity;
     } 
-    epicsMutexUnlock(pPvt->ringBufferLock);
+    epicsMutexUnlock(pPvt->devPvtLock);
 }
 
 static int getCallbackValue(devPvt *pPvt)
@@ -532,7 +533,7 @@ static int getCallbackValue(devPvt *pPvt)
     int ret = 0;
     static const char *functionName="getCallbackValue";
 
-    epicsMutexLock(pPvt->ringBufferLock);
+    epicsMutexLock(pPvt->devPvtLock);
     if (pPvt->ringTail != pPvt->ringHead) {
         if (pPvt->ringBufferOverflows > 0) {
             asynPrint(pPvt->pasynUser, ASYN_TRACE_WARNING,
@@ -547,7 +548,7 @@ static int getCallbackValue(devPvt *pPvt)
                                             pPvt->pr->name, driverName, functionName, pPvt->result.value);
         ret = 1;
     }
-    epicsMutexUnlock(pPvt->ringBufferLock);
+    epicsMutexUnlock(pPvt->devPvtLock);
     return ret;
 }
 
@@ -646,6 +647,7 @@ static long processAo(aoRecord *pr)
     devPvt *pPvt = (devPvt *)pr->dpvt;
     asynStatus status;
 
+    epicsMutexLock(pPvt->devPvtLock);
     if (pPvt->newOutputCallbackValue && getCallbackValue(pPvt)) {
         if (pPvt->result.status == asynSuccess) {
             epicsFloat64 val64 = pPvt->result.value;
@@ -660,10 +662,19 @@ static long processAo(aoRecord *pr)
         epicsFloat64 val64 = pr->oval - pr->aoff;
         if (pr->aslo != 0.0) val64 /= pr->aslo;
         pPvt->result.value = val64;
-        if(pPvt->canBlock) pr->pact = 1;
+        if(pPvt->canBlock) {
+            pr->pact = 1;
+            pPvt->asyncProcessingActive = 1;
+        }
         status = pasynManager->queueRequest(pPvt->pasynUser, 0, 0);
-        if((status==asynSuccess) && pPvt->canBlock) return 0;
-        if(pPvt->canBlock) pr->pact = 0;
+        if((status==asynSuccess) && pPvt->canBlock) {
+            epicsMutexUnlock(pPvt->devPvtLock);
+            return 0;
+        }
+        if(pPvt->canBlock) {
+            pr->pact = 0;
+            pPvt->asyncProcessingActive = 0;
+        }
         reportQueueRequestStatus(pPvt, status);
     }
     pasynEpicsUtils->asynStatusToEpicsAlarm(pPvt->result.status,
@@ -675,6 +686,8 @@ static long processAo(aoRecord *pr)
         pPvt->numDeferredOutputCallbacks--;
     }
     pPvt->newOutputCallbackValue = 0;
+    pPvt->asyncProcessingActive = 0;
+    epicsMutexUnlock(pPvt->devPvtLock);
     if(pPvt->result.status == asynSuccess) {
         return 0;
     }
@@ -711,7 +724,7 @@ static long processAiAverage(aiRecord *pai)
     double dval;
     static const char *functionName="processAiAverage";
 
-    epicsMutexLock(pPvt->ringBufferLock);
+    epicsMutexLock(pPvt->devPvtLock);
 
     if (getCallbackValue(pPvt)) {
         /* Record is I/O Intr scanned and the average has been put in the ring buffer */
@@ -721,14 +734,14 @@ static long processAiAverage(aiRecord *pai)
         if (pPvt->numAverage == 0) {
             recGblSetSevr(pai, UDF_ALARM, INVALID_ALARM);
             pai->udf = 1;
-            epicsMutexUnlock(pPvt->ringBufferLock);
+            epicsMutexUnlock(pPvt->devPvtLock);
             return -2;
         }
         dval = pPvt->sum/pPvt->numAverage;
         pPvt->numAverage = 0;
         pPvt->sum = 0.;
     }
-    epicsMutexUnlock(pPvt->ringBufferLock);
+    epicsMutexUnlock(pPvt->devPvtLock);
     pasynEpicsUtils->asynStatusToEpicsAlarm(pPvt->result.status, 
                                             READ_ALARM, &pPvt->result.alarmStatus,
                                             INVALID_ALARM, &pPvt->result.alarmSeverity);

--- a/asyn/devEpics/devAsynInt32.c
+++ b/asyn/devEpics/devAsynInt32.c
@@ -85,7 +85,7 @@ typedef struct devPvt{
     int               canBlock;
     epicsInt32        deviceLow;
     epicsInt32        deviceHigh;
-    epicsMutexId      ringBufferLock;
+    epicsMutexId      devPvtLock;
     ringBufferElement *ringBuffer;
     int               ringHead;
     int               ringTail;
@@ -97,6 +97,7 @@ typedef struct devPvt{
     int               numAverage;
     int               isAiAverage;
     int               isIOIntrScan;
+    int               asyncProcessingActive;
     int               bipolar;
     epicsInt32        mask;
     epicsInt32        signBit;
@@ -209,7 +210,7 @@ static long initCommon(dbCommon *pr, DBLINK *plink,
     pasynUser = pasynManager->createAsynUser(processCallback, 0);
     pasynUser->userPvt = pPvt;
     pPvt->pasynUser = pasynUser;
-    pPvt->ringBufferLock = epicsMutexCreate();
+    pPvt->devPvtLock = epicsMutexCreate();
  
     /* Parse the link to get addr and port */
     /* We accept 2 different link syntax (@asyn(...) and @asynMask(...)
@@ -557,7 +558,7 @@ static void interruptCallbackInput(void *drvPvt, asynUser *pasynUser,
      * Instead we just return.  There will then be nothing in the ring buffer, so the first
      * read will do a read from the driver, which should be OK. */
     if (!interruptAccept) return;
-    epicsMutexLock(pPvt->ringBufferLock);
+    epicsMutexLock(pPvt->devPvtLock);
     rp = &pPvt->ringBuffer[pPvt->ringHead];
     rp->value = value;
     rp->time = pasynUser->timestamp;
@@ -577,7 +578,7 @@ static void interruptCallbackInput(void *drvPvt, asynUser *pasynUser,
          * element to the ring buffer, not if we just replaced an element. */
         scanIoRequest(pPvt->ioScanPvt);
     }
-    epicsMutexUnlock(pPvt->ringBufferLock);
+    epicsMutexUnlock(pPvt->devPvtLock);
 }
 
 static void interruptCallbackOutput(void *drvPvt, asynUser *pasynUser,
@@ -596,10 +597,7 @@ static void interruptCallbackOutput(void *drvPvt, asynUser *pasynUser,
         "%s %s::%s new value=%d\n",
         pr->name, driverName, functionName, value);
     if (!interruptAccept) return;
-    /* We need the scan lock because we look at PACT and pPvt->numDeferredOutputCallbacks
-     * Must take scan lock before ring buffer lock */
-    dbScanLock(pr);
-    epicsMutexLock(pPvt->ringBufferLock);
+    epicsMutexLock(pPvt->devPvtLock);
     rp = &pPvt->ringBuffer[pPvt->ringHead];
     rp->value = value;
     rp->time = pasynUser->timestamp;
@@ -611,16 +609,15 @@ static void interruptCallbackOutput(void *drvPvt, asynUser *pasynUser,
         pPvt->ringTail = (pPvt->ringTail==pPvt->ringSize) ? 0 : pPvt->ringTail+1;
         pPvt->ringBufferOverflows++;
     } else {
-        /* If PACT is true then this callback was received during asynchronous record processing
-         * Must defer calling callbackRequest until end of record processing */
-        if (pr->pact) {
+        /* If this callback was received during asynchronous record processing
+         * we must defer calling callbackRequest until end of record processing */
+        if (pPvt->asyncProcessingActive) {
             pPvt->numDeferredOutputCallbacks++;
         } else { 
             callbackRequest(&pPvt->outputCallback);
         }
     }
-    epicsMutexUnlock(pPvt->ringBufferLock);
-    dbScanUnlock(pr);
+    epicsMutexUnlock(pPvt->devPvtLock);
 }
 
 static void outputCallbackCallback(CALLBACK *pcb)
@@ -632,6 +629,7 @@ static void outputCallbackCallback(CALLBACK *pcb)
     {
         dbCommon *pr = pPvt->pr;
         dbScanLock(pr);
+        epicsMutexLock(pPvt->devPvtLock);
         pPvt->newOutputCallbackValue = 1;
         dbProcess(pr);
         if (pPvt->newOutputCallbackValue != 0) {
@@ -643,6 +641,7 @@ static void outputCallbackCallback(CALLBACK *pcb)
             getCallbackValue(pPvt);
             pPvt->newOutputCallbackValue = 0;
         }
+        epicsMutexUnlock(pPvt->devPvtLock);
         dbScanUnlock(pr);
     }
 }
@@ -664,7 +663,7 @@ static void interruptCallbackAverage(void *drvPvt, asynUser *pasynUser,
         "%s %s::%s new value=%d\n",
          pai->name, driverName, functionName, value);
     if (!interruptAccept) return;
-    epicsMutexLock(pPvt->ringBufferLock);
+    epicsMutexLock(pPvt->devPvtLock);
     pPvt->numAverage++; 
     pPvt->sum += (double)value;
     /* We use the SVAL field to hold the number of values to average when SCAN=I/O Intr
@@ -709,7 +708,7 @@ static void interruptCallbackAverage(void *drvPvt, asynUser *pasynUser,
         pPvt->result.alarmStatus = pasynUser->alarmStatus;
         pPvt->result.alarmSeverity = pasynUser->alarmSeverity;
     }
-    epicsMutexUnlock(pPvt->ringBufferLock);
+    epicsMutexUnlock(pPvt->devPvtLock);
 }
 
 static void interruptCallbackEnumMbbi(void *drvPvt, asynUser *pasynUser,
@@ -773,22 +772,22 @@ static int getCallbackValue(devPvt *pPvt)
     int ret = 0;
     static const char *functionName="getCallbackValue";
 
-    epicsMutexLock(pPvt->ringBufferLock);
+    epicsMutexLock(pPvt->devPvtLock);
     if (pPvt->ringTail != pPvt->ringHead) {
         if (pPvt->ringBufferOverflows > 0) {
             asynPrint(pPvt->pasynUser, ASYN_TRACE_WARNING,
                 "%s %s::%s warning, %d ring buffer overflows\n",
-                                    pPvt->pr->name, driverName, functionName, pPvt->ringBufferOverflows);
+                pPvt->pr->name, driverName, functionName, pPvt->ringBufferOverflows);
             pPvt->ringBufferOverflows = 0;
         }
         pPvt->result = pPvt->ringBuffer[pPvt->ringTail];
         pPvt->ringTail = (pPvt->ringTail==pPvt->ringSize) ? 0 : pPvt->ringTail+1;
         asynPrint(pPvt->pasynUser, ASYN_TRACEIO_DEVICE,
             "%s %s::%s from ringBuffer value=%d\n",
-                                            pPvt->pr->name, driverName, functionName,pPvt->result.value);
+            pPvt->pr->name, driverName, functionName,pPvt->result.value);
         ret = 1;
     }
-    epicsMutexUnlock(pPvt->ringBufferLock);
+    epicsMutexUnlock(pPvt->devPvtLock);
     return ret;
 }
 
@@ -826,7 +825,7 @@ static long initAi(aiRecord *pr)
      * parseLinkMask */
     if ((pPvt->deviceLow == 0) && (pPvt->deviceHigh == 0)) {
         pasynInt32SyncIO->getBounds(pPvt->pasynUserSync,
-                                &pPvt->deviceLow, &pPvt->deviceHigh);
+                                    &pPvt->deviceLow, &pPvt->deviceHigh);
     }
     convertAi(pr, 1);
     return INIT_OK;
@@ -893,7 +892,7 @@ static long processAiAverage(aiRecord *pr)
     double rval;
     static const char *functionName="processAiAverage";
 
-    epicsMutexLock(pPvt->ringBufferLock);
+    epicsMutexLock(pPvt->devPvtLock);
 
     if (getCallbackValue(pPvt)) {
         /* Record is I/O Intr scanned and the average has been put in the ring buffer */
@@ -903,7 +902,7 @@ static long processAiAverage(aiRecord *pr)
         if (pPvt->numAverage == 0) {
             (void)recGblSetSevr(pr, UDF_ALARM, INVALID_ALARM);
             pr->udf = 1;
-            epicsMutexUnlock(pPvt->ringBufferLock);
+            epicsMutexUnlock(pPvt->devPvtLock);
             return -2;
         }
         rval = pPvt->sum/pPvt->numAverage;
@@ -912,7 +911,7 @@ static long processAiAverage(aiRecord *pr)
         pPvt->numAverage = 0;
         pPvt->sum = 0.;
     }
-    epicsMutexUnlock(pPvt->ringBufferLock);
+    epicsMutexUnlock(pPvt->devPvtLock);
     asynPrint(pPvt->pasynUser, ASYN_TRACEIO_DEVICE,
         "%s %s::%s rval=%d, status=%d\n",pr->name, driverName, functionName, pr->rval, pPvt->result.status);
     pasynEpicsUtils->asynStatusToEpicsAlarm(pPvt->result.status, 
@@ -969,6 +968,7 @@ static long processAo(aoRecord *pr)
     double     value;
     static const char *functionName="processAo";
     
+    epicsMutexLock(pPvt->devPvtLock);
     if (pPvt->newOutputCallbackValue && getCallbackValue(pPvt)) {
         /* We got a callback from the driver */
         if (pPvt->result.status == asynSuccess) {
@@ -989,6 +989,7 @@ static long processAo(aoRecord *pr)
                         "%s %s::%s cvtRawToEngBpt failed\n",
                         pr->name, driverName, functionName);
                     (void)recGblSetSevr(pr, WRITE_ALARM, INVALID_ALARM);
+                     epicsMutexUnlock(pPvt->devPvtLock);
                     return -1;
                 }
             }
@@ -997,10 +998,19 @@ static long processAo(aoRecord *pr)
         }
     } else if(pr->pact == 0) {
         pPvt->result.value = pr->rval;
-        if(pPvt->canBlock) pr->pact = 1;
+        if(pPvt->canBlock) {
+            pr->pact = 1;
+            pPvt->asyncProcessingActive = 1;
+        }
         status = pasynManager->queueRequest(pPvt->pasynUser, 0, 0);
-        if((status==asynSuccess) && pPvt->canBlock) return 0;
-        if(pPvt->canBlock) pr->pact = 0;
+        if((status==asynSuccess) && pPvt->canBlock) {
+            epicsMutexUnlock(pPvt->devPvtLock);
+            return 0;
+        }
+        if(pPvt->canBlock) {
+            pr->pact = 0;
+            pPvt->asyncProcessingActive = 0;
+        }
         reportQueueRequestStatus(pPvt, status);
     }
     pasynEpicsUtils->asynStatusToEpicsAlarm(pPvt->result.status, 
@@ -1012,6 +1022,8 @@ static long processAo(aoRecord *pr)
         pPvt->numDeferredOutputCallbacks--;
     }
     pPvt->newOutputCallbackValue = 0;
+    pPvt->asyncProcessingActive = 0;
+    epicsMutexUnlock(pPvt->devPvtLock);
     if(pPvt->result.status == asynSuccess) {
         return 0;
     }
@@ -1086,6 +1098,7 @@ static long processLo(longoutRecord *pr)
     devPvt *pPvt = (devPvt *)pr->dpvt;
     int status;
 
+    epicsMutexLock(pPvt->devPvtLock);
     if (pPvt->newOutputCallbackValue && getCallbackValue(pPvt)) {
         /* We got a callback from the driver */
         if (pPvt->result.status == asynSuccess) {
@@ -1094,10 +1107,19 @@ static long processLo(longoutRecord *pr)
         }
     } else if(pr->pact == 0) {
         pPvt->result.value = pr->val;
-        if(pPvt->canBlock) pr->pact = 1;
+        if(pPvt->canBlock) {
+            pr->pact = 1;
+            pPvt->asyncProcessingActive = 1;
+        }
         status = pasynManager->queueRequest(pPvt->pasynUser, 0, 0);
-        if((status==asynSuccess) && pPvt->canBlock) return 0;
-        if(pPvt->canBlock) pr->pact = 0;
+        if((status==asynSuccess) && pPvt->canBlock) {
+            epicsMutexUnlock(pPvt->devPvtLock);
+            return 0;
+        }
+        if(pPvt->canBlock) {
+            pr->pact = 0;
+            pPvt->asyncProcessingActive = 0;
+        }
         reportQueueRequestStatus(pPvt, status);
     }
     pasynEpicsUtils->asynStatusToEpicsAlarm(pPvt->result.status, 
@@ -1109,6 +1131,8 @@ static long processLo(longoutRecord *pr)
         pPvt->numDeferredOutputCallbacks--;
     }
     pPvt->newOutputCallbackValue = 0;
+    pPvt->asyncProcessingActive = 0;
+    epicsMutexUnlock(pPvt->devPvtLock);
     if(pPvt->result.status == asynSuccess) {
         return 0;
     }
@@ -1183,6 +1207,7 @@ static long processBo(boRecord *pr)
     devPvt *pPvt = (devPvt *)pr->dpvt;
     int status;
 
+    epicsMutexLock(pPvt->devPvtLock);
     if(pPvt->newOutputCallbackValue && getCallbackValue(pPvt)) {
         /* We got a callback from the driver */
         if (pPvt->result.status == asynSuccess) {
@@ -1192,10 +1217,19 @@ static long processBo(boRecord *pr)
         }
     } else if(pr->pact == 0) {
         pPvt->result.value = pr->rval;
-        if(pPvt->canBlock) pr->pact = 1;
+        if(pPvt->canBlock) {
+            pr->pact = 1;
+            pPvt->asyncProcessingActive = 1;
+        }
         status = pasynManager->queueRequest(pPvt->pasynUser, 0, 0);
-        if((status==asynSuccess) && pPvt->canBlock) return 0;
-        if(pPvt->canBlock) pr->pact = 0;
+        if((status==asynSuccess) && pPvt->canBlock) {
+            epicsMutexUnlock(pPvt->devPvtLock);
+            return 0;
+        }
+        if(pPvt->canBlock) {
+            pr->pact = 0;
+            pPvt->asyncProcessingActive = 0;
+        }
         reportQueueRequestStatus(pPvt, status);
     }
     pasynEpicsUtils->asynStatusToEpicsAlarm(pPvt->result.status, 
@@ -1207,6 +1241,8 @@ static long processBo(boRecord *pr)
         pPvt->numDeferredOutputCallbacks--;
     }
     pPvt->newOutputCallbackValue = 0;
+    pPvt->asyncProcessingActive = 0;
+    epicsMutexUnlock(pPvt->devPvtLock);
     if(pPvt->result.status == asynSuccess) {
         return 0;
     } else {
@@ -1279,11 +1315,13 @@ static long initMbbo(mbboRecord *pr)
     }
     return INIT_DO_NOT_CONVERT;
 }
+
 static long processMbbo(mbboRecord *pr)
 {
     devPvt *pPvt = (devPvt *)pr->dpvt;
     int status;
 
+    epicsMutexLock(pPvt->devPvtLock);
     if(pPvt->newOutputCallbackValue && getCallbackValue(pPvt)) {
         /* We got a callback from the driver */
         if (pPvt->result.status == asynSuccess) {
@@ -1311,10 +1349,19 @@ static long processMbbo(mbboRecord *pr)
         }
     } else if(pr->pact == 0) {
         pPvt->result.value = pr->rval;
-        if(pPvt->canBlock) pr->pact = 1;
+        if(pPvt->canBlock) {
+            pr->pact = 1;
+            pPvt->asyncProcessingActive = 1;
+        }
         status = pasynManager->queueRequest(pPvt->pasynUser, 0, 0);
-        if((status==asynSuccess) && pPvt->canBlock) return 0;
-        if(pPvt->canBlock) pr->pact = 0;
+        if((status==asynSuccess) && pPvt->canBlock) {
+            epicsMutexUnlock(pPvt->devPvtLock);
+            return 0;
+        }
+        if(pPvt->canBlock) {
+            pr->pact = 0;
+            pPvt->asyncProcessingActive = 0;
+        }
         reportQueueRequestStatus(pPvt, status);
     }
     pasynEpicsUtils->asynStatusToEpicsAlarm(pPvt->result.status, 
@@ -1326,6 +1373,8 @@ static long processMbbo(mbboRecord *pr)
         pPvt->numDeferredOutputCallbacks--;
     }
     pPvt->newOutputCallbackValue = 0;
+    pPvt->asyncProcessingActive = 0;
+    epicsMutexUnlock(pPvt->devPvtLock);
     if(pPvt->result.status == asynSuccess) {
         return 0;
     }

--- a/asyn/devEpics/devAsynInt32.c
+++ b/asyn/devEpics/devAsynInt32.c
@@ -1002,15 +1002,11 @@ static long processAo(aoRecord *pr)
             pr->pact = 1;
             pPvt->asyncProcessingActive = 1;
         }
+        epicsMutexUnlock(pPvt->devPvtLock);
         status = pasynManager->queueRequest(pPvt->pasynUser, 0, 0);
-        if((status==asynSuccess) && pPvt->canBlock) {
-            epicsMutexUnlock(pPvt->devPvtLock);
-            return 0;
-        }
-        if(pPvt->canBlock) {
-            pr->pact = 0;
-            pPvt->asyncProcessingActive = 0;
-        }
+        if((status==asynSuccess) && pPvt->canBlock) return 0;
+        epicsMutexLock(pPvt->devPvtLock);
+        if(pPvt->canBlock) pr->pact = 0;
         reportQueueRequestStatus(pPvt, status);
     }
     pasynEpicsUtils->asynStatusToEpicsAlarm(pPvt->result.status, 
@@ -1111,15 +1107,11 @@ static long processLo(longoutRecord *pr)
             pr->pact = 1;
             pPvt->asyncProcessingActive = 1;
         }
+        epicsMutexUnlock(pPvt->devPvtLock);
         status = pasynManager->queueRequest(pPvt->pasynUser, 0, 0);
-        if((status==asynSuccess) && pPvt->canBlock) {
-            epicsMutexUnlock(pPvt->devPvtLock);
-            return 0;
-        }
-        if(pPvt->canBlock) {
-            pr->pact = 0;
-            pPvt->asyncProcessingActive = 0;
-        }
+        if((status==asynSuccess) && pPvt->canBlock) return 0;
+        if(pPvt->canBlock) pr->pact = 0;
+        epicsMutexLock(pPvt->devPvtLock);
         reportQueueRequestStatus(pPvt, status);
     }
     pasynEpicsUtils->asynStatusToEpicsAlarm(pPvt->result.status, 
@@ -1221,15 +1213,11 @@ static long processBo(boRecord *pr)
             pr->pact = 1;
             pPvt->asyncProcessingActive = 1;
         }
+        epicsMutexUnlock(pPvt->devPvtLock);
         status = pasynManager->queueRequest(pPvt->pasynUser, 0, 0);
-        if((status==asynSuccess) && pPvt->canBlock) {
-            epicsMutexUnlock(pPvt->devPvtLock);
-            return 0;
-        }
-        if(pPvt->canBlock) {
-            pr->pact = 0;
-            pPvt->asyncProcessingActive = 0;
-        }
+        if((status==asynSuccess) && pPvt->canBlock) return 0;
+        if(pPvt->canBlock) pr->pact = 0;
+        epicsMutexLock(pPvt->devPvtLock);
         reportQueueRequestStatus(pPvt, status);
     }
     pasynEpicsUtils->asynStatusToEpicsAlarm(pPvt->result.status, 
@@ -1353,15 +1341,11 @@ static long processMbbo(mbboRecord *pr)
             pr->pact = 1;
             pPvt->asyncProcessingActive = 1;
         }
+        epicsMutexUnlock(pPvt->devPvtLock);
         status = pasynManager->queueRequest(pPvt->pasynUser, 0, 0);
-        if((status==asynSuccess) && pPvt->canBlock) {
-            epicsMutexUnlock(pPvt->devPvtLock);
-            return 0;
-        }
-        if(pPvt->canBlock) {
-            pr->pact = 0;
-            pPvt->asyncProcessingActive = 0;
-        }
+        if((status==asynSuccess) && pPvt->canBlock) return 0;
+        if(pPvt->canBlock) pr->pact = 0;
+        epicsMutexLock(pPvt->devPvtLock);
         reportQueueRequestStatus(pPvt, status);
     }
     pasynEpicsUtils->asynStatusToEpicsAlarm(pPvt->result.status, 

--- a/asyn/devEpics/devAsynUInt32Digital.c
+++ b/asyn/devEpics/devAsynUInt32Digital.c
@@ -80,7 +80,7 @@ typedef struct devPvt{
     void              *uint32Pvt;
     void              *registrarPvt;
     int               canBlock;
-    epicsMutexId      ringBufferLock;
+    epicsMutexId      devPvtLock;
     epicsUInt32        mask;
     ringBufferElement *ringBuffer;
     int               ringHead;
@@ -93,6 +93,7 @@ typedef struct devPvt{
     CALLBACK          outputCallback;
     int               newOutputCallbackValue;
     int               numDeferredOutputCallbacks;
+    int               asyncProcessingActive;
     IOSCANPVT         ioScanPvt;
     char              *portName;
     char              *userParam;
@@ -190,7 +191,7 @@ static long initCommon(dbCommon *pr, DBLINK *plink,
     pasynUser = pasynManager->createAsynUser(processCallback, 0);
     pasynUser->userPvt = pPvt;
     pPvt->pasynUser = pasynUser;
-    pPvt->ringBufferLock = epicsMutexCreate();
+    pPvt->devPvtLock = epicsMutexCreate();
     /* Parse the link to get addr and port */
     status = pasynEpicsUtils->parseLinkMask(pasynUser, plink, 
                 &pPvt->portName, &pPvt->addr, &pPvt->mask,&pPvt->userParam);
@@ -462,7 +463,7 @@ static void interruptCallbackInput(void *drvPvt, asynUser *pasynUser,
      * Instead we just return.  There will then be nothing in the ring buffer, so the first
      * read will do a read from the driver, which should be OK. */
     if (!interruptAccept) return;
-    epicsMutexLock(pPvt->ringBufferLock);
+    epicsMutexLock(pPvt->devPvtLock);
     rp = &pPvt->ringBuffer[pPvt->ringHead];
     rp->value = value;
     rp->time = pasynUser->timestamp;
@@ -482,7 +483,7 @@ static void interruptCallbackInput(void *drvPvt, asynUser *pasynUser,
          * new element to the ring buffer, not if we just replaced an element. */
         scanIoRequest(pPvt->ioScanPvt);
     }    
-    epicsMutexUnlock(pPvt->ringBufferLock);
+    epicsMutexUnlock(pPvt->devPvtLock);
 }
 
 static void interruptCallbackOutput(void *drvPvt, asynUser *pasynUser,
@@ -497,8 +498,7 @@ static void interruptCallbackOutput(void *drvPvt, asynUser *pasynUser,
         "%s %s::%s new value=%u\n",
         pr->name, driverName, functionName, value);
     if (!interruptAccept) return;
-    dbScanLock(pr);
-    epicsMutexLock(pPvt->ringBufferLock);
+    epicsMutexLock(pPvt->devPvtLock);
     rp = &pPvt->ringBuffer[pPvt->ringHead];
     rp->value = value;
     rp->time = pasynUser->timestamp;
@@ -510,16 +510,15 @@ static void interruptCallbackOutput(void *drvPvt, asynUser *pasynUser,
         pPvt->ringTail = (pPvt->ringTail==pPvt->ringSize) ? 0 : pPvt->ringTail+1;
         pPvt->ringBufferOverflows++;
     } else {
-        /* If PACT is true then this callback was received during asynchronous record processing
-         * Must defer calling callbackRequest until end of record processing */
-        if (pr->pact) {
+        /* If this callback was received during asynchronous record processing
+         * we must defer calling callbackRequest until end of record processing */
+        if (pPvt->asyncProcessingActive) {
             pPvt->numDeferredOutputCallbacks++;
         } else { 
             callbackRequest(&pPvt->outputCallback);
         }
     }
-    epicsMutexUnlock(pPvt->ringBufferLock);
-    dbScanUnlock(pr);
+    epicsMutexUnlock(pPvt->devPvtLock);
 }
 
 static void outputCallbackCallback(CALLBACK *pcb)
@@ -531,6 +530,7 @@ static void outputCallbackCallback(CALLBACK *pcb)
     {
         dbCommon *pr = pPvt->pr;
         dbScanLock(pr);
+        epicsMutexLock(pPvt->devPvtLock);
         pPvt->newOutputCallbackValue = 1;
         dbProcess(pr);
         if (pPvt->newOutputCallbackValue != 0) {
@@ -542,6 +542,7 @@ static void outputCallbackCallback(CALLBACK *pcb)
             getCallbackValue(pPvt);
             pPvt->newOutputCallbackValue = 0;
         }
+        epicsMutexUnlock(pPvt->devPvtLock);
         dbScanUnlock(pr);
     }
 }
@@ -607,7 +608,7 @@ static int getCallbackValue(devPvt *pPvt)
     int ret = 0;
     static const char *functionName="getCallbackValue";
 
-    epicsMutexLock(pPvt->ringBufferLock);
+    epicsMutexLock(pPvt->devPvtLock);
     if (pPvt->ringTail != pPvt->ringHead) {
         if (pPvt->ringBufferOverflows > 0) {
             asynPrint(pPvt->pasynUser, ASYN_TRACE_WARNING,
@@ -622,7 +623,7 @@ static int getCallbackValue(devPvt *pPvt)
                                             pPvt->pr->name, driverName, functionName,pPvt->result.value);
         ret = 1;
     }
-    epicsMutexUnlock(pPvt->ringBufferLock);
+    epicsMutexUnlock(pPvt->devPvtLock);
     return ret;
 }
 
@@ -726,6 +727,7 @@ static long processBo(boRecord *pr)
     devPvt *pPvt = (devPvt *)pr->dpvt;
     asynStatus status;
 
+    epicsMutexLock(pPvt->devPvtLock);
     if(pPvt->newOutputCallbackValue && getCallbackValue(pPvt)) {
         /* We got a callback from the driver */
         if (pPvt->result.status == asynSuccess) {
@@ -735,10 +737,19 @@ static long processBo(boRecord *pr)
         }
     } else if(pr->pact == 0) {
         pPvt->result.value = pr->rval;;
-        if(pPvt->canBlock) pr->pact = 1;
+        if(pPvt->canBlock) {
+            pr->pact = 1;
+            pPvt->asyncProcessingActive = 1;
+        }
         status = pasynManager->queueRequest(pPvt->pasynUser, 0, 0);
-        if((status==asynSuccess) && pPvt->canBlock) return 0;
-        if(pPvt->canBlock) pr->pact = 0;
+        if((status==asynSuccess) && pPvt->canBlock) {
+            epicsMutexUnlock(pPvt->devPvtLock);
+            return 0;
+        }
+        if(pPvt->canBlock) {
+            pr->pact = 0;
+            pPvt->asyncProcessingActive = 0;
+        }
         reportQueueRequestStatus(pPvt, status);
     }
     pasynEpicsUtils->asynStatusToEpicsAlarm(pPvt->result.status, 
@@ -750,6 +761,8 @@ static long processBo(boRecord *pr)
         pPvt->numDeferredOutputCallbacks--;
     }
     pPvt->newOutputCallbackValue = 0;
+    pPvt->asyncProcessingActive = 0;
+    epicsMutexUnlock(pPvt->devPvtLock);
     if(pPvt->result.status == asynSuccess) {
         return 0;
     }
@@ -824,6 +837,7 @@ static long processLo(longoutRecord *pr)
     devPvt *pPvt = (devPvt *)pr->dpvt;
     asynStatus status;
 
+    epicsMutexLock(pPvt->devPvtLock);
     if(pPvt->newOutputCallbackValue && getCallbackValue(pPvt)) {
         /* We got a callback from the driver */
         if (pPvt->result.status == asynSuccess) {
@@ -832,10 +846,19 @@ static long processLo(longoutRecord *pr)
         }
     } else if(pr->pact == 0) {
         pPvt->result.value = pr->val & pPvt->mask;
-        if(pPvt->canBlock) pr->pact = 1;
+        if(pPvt->canBlock) {
+            pr->pact = 1;
+            pPvt->asyncProcessingActive = 1;
+        }
         status = pasynManager->queueRequest(pPvt->pasynUser, 0, 0);
-        if((status==asynSuccess) && pPvt->canBlock) return 0;
-        if(pPvt->canBlock) pr->pact = 0;
+        if((status==asynSuccess) && pPvt->canBlock) {
+            epicsMutexUnlock(pPvt->devPvtLock);
+            return 0;
+        }
+        if(pPvt->canBlock) {
+            pr->pact = 0;
+            pPvt->asyncProcessingActive = 0;
+        }
         reportQueueRequestStatus(pPvt, status);
     }
     pasynEpicsUtils->asynStatusToEpicsAlarm(pPvt->result.status, 
@@ -847,6 +870,8 @@ static long processLo(longoutRecord *pr)
         pPvt->numDeferredOutputCallbacks--;
     }
     pPvt->newOutputCallbackValue = 0;
+    pPvt->asyncProcessingActive = 0;
+    epicsMutexUnlock(pPvt->devPvtLock);
     if(pPvt->result.status == asynSuccess) {
         return 0;
     }
@@ -920,11 +945,13 @@ static long initMbbo(mbboRecord *pr)
     }
     return INIT_DO_NOT_CONVERT;
 }
+
 static long processMbbo(mbboRecord *pr)
 {
     devPvt *pPvt = (devPvt *)pr->dpvt;
     asynStatus status;
 
+    epicsMutexLock(pPvt->devPvtLock);
     if (pPvt->newOutputCallbackValue && getCallbackValue(pPvt)) {
         /* We got a callback from the driver */
         if (pPvt->result.status == asynSuccess) {
@@ -951,10 +978,19 @@ static long processMbbo(mbboRecord *pr)
         }
     } else if(pr->pact == 0) {
         pPvt->result.value = pr->rval;
-        if(pPvt->canBlock) pr->pact = 1;
+        if(pPvt->canBlock) {
+            pr->pact = 1;
+            pPvt->asyncProcessingActive = 1;
+        }
         status = pasynManager->queueRequest(pPvt->pasynUser, 0, 0);
-        if((status==asynSuccess) && pPvt->canBlock) return 0;
-        if(pPvt->canBlock) pr->pact = 0;
+        if((status==asynSuccess) && pPvt->canBlock) {
+            epicsMutexUnlock(pPvt->devPvtLock);
+            return 0;
+        }
+        if(pPvt->canBlock) {
+            pr->pact = 0;
+            pPvt->asyncProcessingActive = 0;
+        }
         reportQueueRequestStatus(pPvt, status);
     }
     pasynEpicsUtils->asynStatusToEpicsAlarm(pPvt->result.status, 
@@ -966,6 +1002,8 @@ static long processMbbo(mbboRecord *pr)
         pPvt->numDeferredOutputCallbacks--;
     }
     pPvt->newOutputCallbackValue = 0;
+    pPvt->asyncProcessingActive = 0;
+    epicsMutexUnlock(pPvt->devPvtLock);
     if(pPvt->result.status == asynSuccess) {
         return 0;
     }
@@ -1050,11 +1088,13 @@ static long initMbboDirect(mbboDirectRecord *pr)
     }
     return INIT_DO_NOT_CONVERT;
 }
+
 static long processMbboDirect(mbboDirectRecord *pr)
 {
     devPvt *pPvt = (devPvt *)pr->dpvt;
     asynStatus status;
 
+    epicsMutexLock(pPvt->devPvtLock);
     if (pPvt->newOutputCallbackValue && getCallbackValue(pPvt)) {
         /* We got a callback from the driver */
         if (pPvt->result.status == asynSuccess) {
@@ -1074,10 +1114,19 @@ static long processMbboDirect(mbboDirectRecord *pr)
         }
     } else if(pr->pact == 0) {
         pPvt->result.value = pr->rval;
-        if(pPvt->canBlock) pr->pact = 1;
+        if(pPvt->canBlock) {
+            pr->pact = 1;
+            pPvt->asyncProcessingActive = 1;
+        }
         status = pasynManager->queueRequest(pPvt->pasynUser, 0, 0);
-        if((status==asynSuccess) && pPvt->canBlock) return 0;
-        if(pPvt->canBlock) pr->pact = 0;
+        if((status==asynSuccess) && pPvt->canBlock) {
+            epicsMutexUnlock(pPvt->devPvtLock);
+            return 0;
+        }
+        if(pPvt->canBlock) {
+            pr->pact = 0;
+            pPvt->asyncProcessingActive = 0;
+        }
         reportQueueRequestStatus(pPvt, status);
     }
     pasynEpicsUtils->asynStatusToEpicsAlarm(pPvt->result.status, 
@@ -1089,6 +1138,8 @@ static long processMbboDirect(mbboDirectRecord *pr)
         pPvt->numDeferredOutputCallbacks--;
     }
     pPvt->newOutputCallbackValue = 0;
+    pPvt->asyncProcessingActive = 0;
+    epicsMutexUnlock(pPvt->devPvtLock);
     if(pPvt->result.status == asynSuccess) {
         return 0;
     }

--- a/asyn/devEpics/devAsynUInt32Digital.c
+++ b/asyn/devEpics/devAsynUInt32Digital.c
@@ -741,15 +741,11 @@ static long processBo(boRecord *pr)
             pr->pact = 1;
             pPvt->asyncProcessingActive = 1;
         }
+        epicsMutexUnlock(pPvt->devPvtLock);
         status = pasynManager->queueRequest(pPvt->pasynUser, 0, 0);
-        if((status==asynSuccess) && pPvt->canBlock) {
-            epicsMutexUnlock(pPvt->devPvtLock);
-            return 0;
-        }
-        if(pPvt->canBlock) {
-            pr->pact = 0;
-            pPvt->asyncProcessingActive = 0;
-        }
+        if((status==asynSuccess) && pPvt->canBlock) return 0;
+        if(pPvt->canBlock) pr->pact = 0;
+        epicsMutexLock(pPvt->devPvtLock);
         reportQueueRequestStatus(pPvt, status);
     }
     pasynEpicsUtils->asynStatusToEpicsAlarm(pPvt->result.status, 
@@ -850,15 +846,11 @@ static long processLo(longoutRecord *pr)
             pr->pact = 1;
             pPvt->asyncProcessingActive = 1;
         }
+        epicsMutexUnlock(pPvt->devPvtLock);
         status = pasynManager->queueRequest(pPvt->pasynUser, 0, 0);
-        if((status==asynSuccess) && pPvt->canBlock) {
-            epicsMutexUnlock(pPvt->devPvtLock);
-            return 0;
-        }
-        if(pPvt->canBlock) {
-            pr->pact = 0;
-            pPvt->asyncProcessingActive = 0;
-        }
+        if((status==asynSuccess) && pPvt->canBlock) return 0;
+        if(pPvt->canBlock) pr->pact = 0;
+        epicsMutexLock(pPvt->devPvtLock);
         reportQueueRequestStatus(pPvt, status);
     }
     pasynEpicsUtils->asynStatusToEpicsAlarm(pPvt->result.status, 
@@ -982,15 +974,11 @@ static long processMbbo(mbboRecord *pr)
             pr->pact = 1;
             pPvt->asyncProcessingActive = 1;
         }
+        epicsMutexUnlock(pPvt->devPvtLock);
         status = pasynManager->queueRequest(pPvt->pasynUser, 0, 0);
-        if((status==asynSuccess) && pPvt->canBlock) {
-            epicsMutexUnlock(pPvt->devPvtLock);
-            return 0;
-        }
-        if(pPvt->canBlock) {
-            pr->pact = 0;
-            pPvt->asyncProcessingActive = 0;
-        }
+        if((status==asynSuccess) && pPvt->canBlock) return 0;
+        if(pPvt->canBlock) pr->pact = 0;
+        epicsMutexLock(pPvt->devPvtLock);
         reportQueueRequestStatus(pPvt, status);
     }
     pasynEpicsUtils->asynStatusToEpicsAlarm(pPvt->result.status, 
@@ -1118,15 +1106,11 @@ static long processMbboDirect(mbboDirectRecord *pr)
             pr->pact = 1;
             pPvt->asyncProcessingActive = 1;
         }
+        epicsMutexUnlock(pPvt->devPvtLock);
         status = pasynManager->queueRequest(pPvt->pasynUser, 0, 0);
-        if((status==asynSuccess) && pPvt->canBlock) {
-            epicsMutexUnlock(pPvt->devPvtLock);
-            return 0;
-        }
-        if(pPvt->canBlock) {
-            pr->pact = 0;
-            pPvt->asyncProcessingActive = 0;
-        }
+        if((status==asynSuccess) && pPvt->canBlock) return 0;
+        if(pPvt->canBlock) pr->pact = 0;
+        epicsMutexLock(pPvt->devPvtLock);
         reportQueueRequestStatus(pPvt, status);
     }
     pasynEpicsUtils->asynStatusToEpicsAlarm(pPvt->result.status, 

--- a/iocBoot/ioctestOutputCallback/testOutputCallback.pro
+++ b/iocBoot/ioctestOutputCallback/testOutputCallback.pro
@@ -1,0 +1,17 @@
+; This program tests deadlocks in asyn:REABACK callbacks 
+
+PREFIX = 'testOutputCallback:'
+
+counter = 0L
+while 1 do begin
+    t = caput(PREFIX + 'LongoutInt32', 0)
+    t = caput(PREFIX + 'BoInt32', 0)
+    t = caput(PREFIX + 'LongoutUInt32D', 0)
+    t = caput(PREFIX + 'AoFloat64', 0)
+    t = caput(PREFIX + 'Stringout', "test")
+    t = caput(PREFIX + 'TriggerCallbacks', 1)
+    
+    print, counter
+    counter += 1
+endwhile
+end


### PR DESCRIPTION
This pull request mostly fixes #80. 

The fix is to use a local variable to hold the information on whether asynchronous record processing is in progress, rather than using PACT.  This way only a local mutex, and not dbScanLock, can be used.

The fix has been applied devAsynInt32, devAsynOctet, and devAsynUInt32Digital.  It cannot be applied to devAsynOctet at this time.  This is because devAsynOctet copies the value directly to the record in the callback function if ring buffers are disabled, which is the default.  dbScanLock must therefore be called.  devAsynOctet output records with asyn:READBACK=1 and synchronous drivers may thus experience deadlocks.
