### PR TITLE
Enable HOSTINFO when not connected

### DIFF
--- a/asyn/asynRecord/asynRecord.c
+++ b/asyn/asynRecord/asynRecord.c
@@ -1276,10 +1276,11 @@ static asynStatus connectDevice(asynRecord * pasynRec)
         pasynUserConnect = pasynManager->duplicateAsynUser(pasynUser,
             asynCallbackSpecial, queueTimeoutCallbackSpecial);
         pasynUserConnect->userData = pasynManager->memMalloc(sizeof(*pmsg));
+        pasynUserConnect->reason = ASYN_REASON_QUEUE_EVEN_IF_NOT_CONNECTED;
         pmsg = (callbackMessage *)pasynUserConnect->userData;
         pmsg->callbackType = callbackGetOption;
         status = pasynManager->queueRequest(pasynUserConnect,
-                                        asynQueuePriorityLow,QUEUE_TIMEOUT);
+                                        asynQueuePriorityConnect,QUEUE_TIMEOUT);
         if(status!=asynSuccess) {
             reportError(pasynRec, asynError, 
                 "queueRequest failed\n");

--- a/asyn/asynRecord/asynRecord.c
+++ b/asyn/asynRecord/asynRecord.c
@@ -562,6 +562,11 @@ static long special(struct dbAddr * paddr, int after)
     } else {
         priority = asynQueuePriorityLow;
     }
+    if (fieldIndex == asynRecordHOSTINFO) {
+        /* Enable changing host:port when not connected */
+        priority = asynQueuePriorityConnect;
+        pasynUserSpecial->reason = ASYN_REASON_QUEUE_EVEN_IF_NOT_CONNECTED;
+    }
     status = pasynManager->queueRequest(pasynUserSpecial,
                                         priority,QUEUE_TIMEOUT);
     if(status!=asynSuccess) {

--- a/asyn/drvAsynSerial/drvAsynIPPort.c
+++ b/asyn/drvAsynSerial/drvAsynIPPort.c
@@ -852,6 +852,7 @@ getOption(void *drvPvt, asynUser *pasynUser,
     ttyController_t *tty = (ttyController_t *)drvPvt;
     int l;
 
+    val[0] = '\0';
     assert(tty);
     if (epicsStrCaseCmp(key, "disconnectOnReadTimeout") == 0) {
         l = epicsSnprintf(val, valSize, "%c", tty->disconnectOnReadTimeout ? 'Y' : 'N');

--- a/asyn/drvAsynSerial/drvAsynSerialPort.c
+++ b/asyn/drvAsynSerial/drvAsynSerialPort.c
@@ -139,6 +139,7 @@ getOption(void *drvPvt, asynUser *pasynUser,
     ttyController_t *tty = (ttyController_t *)drvPvt;
     int l;
 
+    val[0] = '\0';
     if (epicsStrCaseCmp(key, "baud") == 0) {
         l = epicsSnprintf(val, valSize, "%d", tty->baud);
     }

--- a/asyn/drvAsynSerial/drvAsynSerialPortWin32.c
+++ b/asyn/drvAsynSerial/drvAsynSerialPortWin32.c
@@ -91,6 +91,7 @@ getOption(void *drvPvt, asynUser *pasynUser,
     DWORD error;
     int l;
     
+    val[0] = '\0';
     assert(tty);
     if (tty->commHandle == INVALID_HANDLE_VALUE) {
         epicsSnprintf(pasynUser->errorMessage,pasynUser->errorMessageSize,


### PR DESCRIPTION
The HOSTINFO field is not initialized correctly and writing to it is ignored (with queueRequest failed) when not connected.
This PR fixes both cases by issuing queueRequest with priority set to asynQueuePriorityConnect and reason to ASYN_REASON_QUEUE_EVEN_IF_NOT_CONNECTED.