### PR TITLE
asynEpicsUtils.c: Remove compiler warnings about strncpy

### DIFF
--- a/asyn/devEpics/asynEpicsUtils.c
+++ b/asyn/devEpics/asynEpicsUtils.c
@@ -86,10 +86,7 @@ static asynStatus parseLink(asynUser *pasynUser, DBLINK *plink,
         if(*p) {
             p = skipWhite(p,0);
             if(*p) {
-                len = strlen(p);
-                *userParam = mallocMustSucceed(len+1,"asynEpicsUtils:parseLink");
-                strncpy(*userParam,p,len);
-                (*userParam)[len] = 0;
+                *userParam = epicsStrDup(p);
             }
         }
         break;
@@ -139,10 +136,7 @@ userParams:
         if(*p) {
             p = skipWhite(p,0);
             if(userParam&& *p) {
-                len = strlen(p);
-                *userParam = mallocMustSucceed(len+1,"asynEpicsUtils:parseLink");
-                strncpy(*userParam,p,len);
-                (*userParam)[len] = 0;
+                *userParam = epicsStrDup(p);
             }
         }
         break;
@@ -221,10 +215,7 @@ userParams:
     if(*p) {
         p = skipWhite(p,0);
         if(userParam&& *p) {
-            len = strlen(p);
-            *userParam = mallocMustSucceed(len+1,"asynEpicsUtils:parseLink");
-            strncpy(*userParam,p,len);
-            (*userParam)[len] = 0;
+          *userParam = epicsStrDup(p);
         }
     }
     return(asynSuccess);


### PR DESCRIPTION
The code snippet
  len = strlen(str);
  dst = malloc(len + 1);
  strncpy(dst, src, len);
  dst[len] = '\0';

Gives a compiler warning:
  strncpy’ output truncated before terminating nul copying as many bytes
  from a string as its length [-Wstringop-truncation

As the dst string has the exact right length, we don't need strncpy.
Use memcpy instead.