### PR TITLE
asynRecord.: Remove warning `...comparison of unsigned enum < 0...`

### DIFF
--- a/asyn/asynRecord/asynRecord.c
+++ b/asyn/asynRecord/asynRecord.c
@@ -2064,7 +2064,7 @@ static void resetError(asynRecord * pasynRec)
 static const char * asynExceptionStrings[] = { ASYN_EXCEPTION_STRINGS };
 const char * asynExceptionToString( asynException e )
 {
-    if ( e < 0 || e > asynExceptionTraceIOTruncateSize )
+    if ((size_t)e > asynExceptionTraceIOTruncateSize)
         return "Invalid Exception Number!";
     return asynExceptionStrings[e];
 }


### PR DESCRIPTION
In asynExceptionToString() a range check is done to make sure that
we don't read outside asynExceptionStrings[].

The current code gives a warning, since modern compiler detects
that this very enum is always >= 0 and a comparison against < 0
does not make sense,

A more clean way of accessing an array is to use a variable of type size_t.
Cast the enum into size_t before doing the range check.
Use a help variable "idx" for this, the compiler will optimize it away.