### PR TITLE
Remove the path when printing file/line

### DIFF
--- a/asyn/asynDriver/asynManager.c
+++ b/asyn/asynDriver/asynManager.c
@@ -472,6 +472,17 @@ static void reportConnectStatus(port *pport, portConnectStatus status, const cha
     }
 }
 
+static const char *asynStripPath(const char *file)
+{
+  const char *ret = strrchr(file, '/');
+  if (ret) return ret + 1;
+#if (defined(CYGWIN32) || defined(_WIN32))
+  ret = strrchr(file, '\\');
+  if (ret) return ret + 1;
+#endif
+  return file;
+}
+
 static void asynInit(void)
 {
     int i;
@@ -2827,6 +2838,7 @@ static size_t printPort(FILE *fp, asynUser *pasynUser)
 static size_t printSource(FILE *fp, const char *file, int line)
 {
     int      nout = 0;
+    file = asynStripPath(file);
 
     if(fp) {
         nout = fprintf(fp,"[%s:%d] ", file, line);
@@ -2870,6 +2882,7 @@ static int traceVprintSource(asynUser *pasynUser,int reason, const char *file, i
     int      nout = 0;
     FILE     *fp;
 
+    file = asynStripPath(file);
     if(!(reason & ptracePvt->traceMask)) return 0;
     epicsMutexMustLock(pasynBase->lockTrace);
     fp = getTraceFile(pasynUser);


### PR DESCRIPTION
When the file/line printing is enabled by the bit ASYN_TRACEINFO_SOURCE,
file names are printed with help of the __FILE__ macro.
Due to our build system, the compiler is invoked with file names
like "../devMotorAsyn.c", and this is what we find in the IOC log file later.

However, the "../" is no useful information, so make it possible to
skip the "path-component" from file before the printing is done.

This will shorten the IOC log a little bit, and make it easier to read.