### PR TITLE
Remove bitwise or when setting ASYN_EOM_CNT

### DIFF
--- a/asyn/miscellaneous/asynInterposeEos.c
+++ b/asyn/miscellaneous/asynInterposeEos.c
@@ -222,7 +222,7 @@ static asynStatus readIt(void *ppvt,asynUser *pasynUser,
                 }
             }
             if (nRead >= maxchars)  {
-                eom |= ASYN_EOM_CNT;
+                eom = ASYN_EOM_CNT;
                 break;
             }
             continue;


### PR DESCRIPTION
AsynInterposeEos checks each byte for EOS. If it cannot find it and nRead >= maxchars, then it sets the eom to CNT using a bitwise or. In this way, multiple flags can be propagated to the requestor of the read. Since CNT is not an end flag, but other two (EOS and END) are, it does not make sense to propagate a combination of end and non-end flag. Thus if the nRead >= maxchars is true, eom = ASYN\_EOM\_CNT.

**Possible problems:**
If there is a case a read requestor anticipates eom = ASYN\_EOM\_END, then this fix could cause a problem. But asynInterposeEos should probably not even be used be used in this case.

**Tests:**
Testing done with `vxi11Configure("$(PORT)", "$(ADDR)", 0, 0, "Inst0")` and `asynInterposeEosConfig("$(PORT)", 0, 1, 1)` for vxi11 and `drvAsynIPPortConfigure("$(PORT)", "127.0.0.1:3500")` for tcp (but note that it was a simple test using netcat). Tests include messages longer and shorter than 64 chars and use streamdevice, which has a buffer limited to 64 chars.

**Expected results:**
If the message is longer than 64 chars, return 64 chars and eom = CNT. Streamdevice repeats read until eom = EOS is received.
If the message is shorter than 64 chars, return the short message and eom = EOS.

**Test logs:**

Test long with vxi11
```
2020/02/20 13:21:52.938838 sigGen01 AsynDriverInterface.cc:956: AsynDriverInterface::readHandler(debug): read returned asynSuccess: ioAction=Read received=63, eomReason=CNT, buffer="C1:BSWV WVTP,PULSE,FRQ,1000HZ,PERI,0.001S,AMP,4V,AMPVRMS,2Vrms,"
2020/02/20 13:21:52.938880 sigGen01 AsynDriverInterface.cc:994: AsynDriverInterface::readHandler(debug): received 63 of 63 bytes "C1:BSWV WVTP,PULSE,FRQ,1000HZ,PERI,0.001S,AMP,4V,AMPVRMS,2Vrms," eomReason=CNT
2020/02/20 13:21:52.938887 sigGen01 StreamCore.cc:943: StreamCore::readCallback(debug, StreamIoSuccess input="C1:BSWV WVTP,PULSE,FRQ,1000HZ,PERI,0.001S,AMP,4V,AMPVRMS,2Vrms,", size=63)
2020/02/20 13:21:52.938891 sigGen01 StreamCore.cc:993: StreamCore::readCallback(debug) inputBuffer="C1:BSWV WVTP,PULSE,FRQ,1000HZ,PERI,0.001S,AMP,4V,AMPVRMS,2Vrms,", size 63
2020/02/20 13:21:52.938897 sigGen01 StreamCore.cc:1038: StreamCore::readCallback(debug) inTerminator <0a> not found
2020/02/20 13:21:52.938900 sigGen01 StreamCore.cc:1074: StreamCore::readCallback(debug) wait for more input
2020/02/20 13:21:52.938903 sigGen01 AsynDriverInterface.cc:1127: AsynDriverInterface::readHandler(debug) readMore=-1 bytesToRead=63
2020/02/20 13:21:52.938906 sigGen01 AsynDriverInterface.cc:948: AsynDriverInterface::readHandler(debug): ioAction=Read read(..., bytesToRead=63, ...) [timeout=0.1 sec]
2020/02/20 13:21:52.938913 sigGen01 AsynDriverInterface.cc:956: AsynDriverInterface::readHandler(debug): read returned asynSuccess: ioAction=Read received=63, eomReason=CNT, buffer="OFST,0V,HLEV,2V,LLEV,-2V,DUTY,20,WIDTH,0.0002,RISE,1.68e-08S,FA"
2020/02/20 13:21:52.938917 sigGen01 AsynDriverInterface.cc:994: AsynDriverInterface::readHandler(debug): received 63 of 63 bytes "OFST,0V,HLEV,2V,LLEV,-2V,DUTY,20,WIDTH,0.0002,RISE,1.68e-08S,FA" eomReason=CNT
2020/02/20 13:21:52.938920 sigGen01 StreamCore.cc:943: StreamCore::readCallback(debug, StreamIoSuccess input="OFST,0V,HLEV,2V,LLEV,-2V,DUTY,20,WIDTH,0.0002,RISE,1.68e-08S,FA", size=63)
2020/02/20 13:21:52.938925 sigGen01 StreamCore.cc:993: StreamCore::readCallback(debug) inputBuffer="C1:BSWV WVTP,PULSE,FRQ,1000HZ,PERI,0.001S,AMP,4V,AMPVRMS,2Vrms,OFST,0V,HLEV,2V,LLEV,-2V,DUTY,20,WIDTH,0.0002,RISE,1.68e-08S,FA", size 126
2020/02/20 13:21:52.938929 sigGen01 StreamCore.cc:1038: StreamCore::readCallback(debug) inTerminator <0a> not found
2020/02/20 13:21:52.938932 sigGen01 StreamCore.cc:1074: StreamCore::readCallback(debug) wait for more input
2020/02/20 13:21:52.938935 sigGen01 AsynDriverInterface.cc:1127: AsynDriverInterface::readHandler(debug) readMore=-1 bytesToRead=63
2020/02/20 13:21:52.938939 sigGen01 AsynDriverInterface.cc:948: AsynDriverInterface::readHandler(debug): ioAction=Read read(..., bytesToRead=63, ...) [timeout=0.1 sec]
2020/02/20 13:21:52.938942 sigGen01 AsynDriverInterface.cc:956: AsynDriverInterface::readHandler(debug): read returned asynSuccess: ioAction=Read received=18, eomReason=EOS, buffer="LL,1.68e-08S,DLY,0"
2020/02/20 13:21:52.938965 sigGen01 AsynDriverInterface.cc:994: AsynDriverInterface::readHandler(debug): received 18 of 63 bytes "LL,1.68e-08S,DLY,0" eomReason=EOS
2020/02/20 13:21:52.938969 sigGen01 StreamCore.cc:943: StreamCore::readCallback(debug, StreamIoEnd input="LL,1.68e-08S,DLY,0", size=18)
2020/02/20 13:21:52.938974 sigGen01 StreamCore.cc:993: StreamCore::readCallback(debug) inputBuffer="C1:BSWV WVTP,PULSE,FRQ,1000HZ,PERI,0.001S,AMP,4V,AMPVRMS,2Vrms,OFST,0V,HLEV,2V,LLEV,-2V,DUTY,20,WIDTH,0.0002,RISE,1.68e-08S,FALL,1.68e-08S,DLY,0", size 144
```
Working as expected.

Test short with vxi11
```
2020/02/20 13:24:01.751847 sigGen01 AsynDriverInterface.cc:956: AsynDriverInterface::readHandler(debug): read returned asynSuccess: ioAction=Read received=23, eomReason=EOS+END, buffer="C1:BSWV WVTP,DC,OFST,0V"
2020/02/20 13:24:01.751872 sigGen01 AsynDriverInterface.cc:994: AsynDriverInterface::readHandler(debug): received 23 of 63 bytes "C1:BSWV WVTP,DC,OFST,0V" eomReason=EOS+END
2020/02/20 13:24:01.751878 sigGen01 StreamCore.cc:943: StreamCore::readCallback(debug, StreamIoEnd input="C1:BSWV WVTP,DC,OFST,0V", size=23)
2020/02/20 13:24:01.751881 sigGen01 StreamCore.cc:993: StreamCore::readCallback(debug) inputBuffer="C1:BSWV WVTP,DC,OFST,0V", size 23
```
Note that when read does not have to be repeated, eom is still EOS+END. It should not matter because both are end flags, but I would still like to check with someone more familiar with the code.

Test long with tcp
```
2020/02/20 13:14:59.286528 sigGen01 AsynDriverInterface.cc:956: AsynDriverInterface::readHandler(debug): read returned asynSuccess: ioAction=None received=63, eomReason=CNT, buffer="111111111111111111111111111111111111111111111111111111111111111"
2020/02/20 13:14:59.286533 sigGen01 AsynDriverInterface.cc:981: AsynDriverInterface::readHandler(debug): AsyncRead poll: received 63 of 63 bytes "111111111111111111111111111111111111111111111111111111111111111" eomReason=CNT [data ignored]
2020/02/20 13:14:59.286549 sigGen01 AsynDriverInterface.cc:1127: AsynDriverInterface::readHandler(debug) readMore=-1 bytesToRead=63
2020/02/20 13:14:59.286554 sigGen01 AsynDriverInterface.cc:948: AsynDriverInterface::readHandler(debug): ioAction=None read(..., bytesToRead=63, ...) [timeout=0.1 sec]
2020/02/20 13:14:59.286560 sigGen01 AsynDriverInterface.cc:956: AsynDriverInterface::readHandler(debug): read returned asynSuccess: ioAction=None received=63, eomReason=CNT, buffer="111111111111111111111111111111111111111111111111111111111111111"
2020/02/20 13:14:59.286568 sigGen01 AsynDriverInterface.cc:981: AsynDriverInterface::readHandler(debug): AsyncRead poll: received 63 of 63 bytes "111111111111111111111111111111111111111111111111111111111111111" eomReason=CNT [data ignored]
2020/02/20 13:14:59.286578 sigGen01 AsynDriverInterface.cc:1127: AsynDriverInterface::readHandler(debug) readMore=-1 bytesToRead=63
2020/02/20 13:14:59.286581 sigGen01 AsynDriverInterface.cc:948: AsynDriverInterface::readHandler(debug): ioAction=None read(..., bytesToRead=63, ...) [timeout=0.1 sec]
2020/02/20 13:14:59.286588 sigGen01 AsynDriverInterface.cc:956: AsynDriverInterface::readHandler(debug): read returned asynSuccess: ioAction=None received=45, eomReason=EOS, buffer="111111111111111111111111111111111111111111111"
2020/02/20 13:14:59.286592 sigGen01 AsynDriverInterface.cc:981: AsynDriverInterface::readHandler(debug): AsyncRead poll: received 45 of 63 bytes "111111111111111111111111111111111111111111111" eomReason=EOS [data ignored]
2020/02/20 13:14:59.286605 sigGen01 AsynDriverInterface.cc:1127: AsynDriverInterface::readHandler(debug) readMore=-1 bytesToRead=63
2020/02/20 13:14:59.286608 sigGen01 AsynDriverInterface.cc:948: AsynDriverInterface::readHandler(debug): ioAction=None read(..., bytesToRead=63, ...) [timeout=0.1 sec]
2020/02/20 13:14:59.286549 cbLow StreamEpics.cc:1047: recordProcessCallback(debug) processing record
```
Working as expected.

Test short with tcp
```
2020/02/20 13:28:12.652719 sigGen01 AsynDriverInterface.cc:956: AsynDriverInterface::readHandler(debug): read returned asynSuccess: ioAction=None received=26, eomReason=EOS, buffer="11111111111111111111111111"
2020/02/20 13:28:12.652723 sigGen01 AsynDriverInterface.cc:981: AsynDriverInterface::readHandler(debug): AsyncRead poll: received 26 of 63 bytes "11111111111111111111111111" eomReason=EOS [data ignored]
2020/02/20 13:28:12.652727 sigGen01 AsynDriverInterface.cc:1127: AsynDriverInterface::readHandler(debug) readMore=-1 bytesToRead=63
2020/02/20 13:28:12.652729 sigGen01 AsynDriverInterface.cc:948: AsynDriverInterface::readHandler(debug): ioAction=None read(..., bytesToRead=63, ...) [timeout=0.1 sec]
2020/02/20 13:28:12.652745 cbLow StreamEpics.cc:1047: recordProcessCallback(debug) processing record
```
Working as expected.

Closes #105
