### PR TITLE
check for sncseq and use its libraries in the build

### DIFF
--- a/testEpicsApp/src/Makefile
+++ b/testEpicsApp/src/Makefile
@@ -23,6 +23,9 @@ testEpicsSupport_LIBS += asyn
 ifdef CALC
 testEpicsSupport_LIBS += calc sscan
 endif
+ifdef SNCSEQ
+testEpicsSupport_LIBS += seq pv
+endif
 testEpicsSupport_LIBS += $(EPICS_BASE_IOC_LIBS)
 
 PROD_IOC += testEpics
@@ -36,6 +39,9 @@ testEpics_LIBS += testSupport
 testEpics_LIBS += asyn
 ifdef CALC
 testEpics_LIBS += calc sscan
+endif
+ifdef SNCSEQ
+testEpics_LIBS += seq pv
 endif
 testEpics_LIBS += $(EPICS_BASE_IOC_LIBS)
 


### PR DESCRIPTION
If using sncseq module the build of testEpicsApp fails for me on current master branch. It did not fail on master from January for example. I had to add `seq pv` to the list of LIBS required to build the test.

Here is the error that this pull requests solves for me:

```
/usr/bin/g++  -D_GNU_SOURCE -D_DEFAULT_SOURCE         -DUSE_TYPED_RSET   -D_X86_64_  -DUNIX  -Dlinux     -O3   -Wall      -mtune=generic      -m64  -I. -I../O.Common -I. -I. -I.. -I../../../include/compiler/gcc -I../../../include/os/Linux -I../../../include -I/home/hinkokocevar/work/genicam/epics-base/include/compiler/gcc -I/home/hinkokocevar/work/genicam/epics-base/include/os/Linux -I/home/hinkokocevar/work/genicam/epics-base/include  -I/home/hinkokocevar/work/genicam/autosave/include/os/Linux -I/home/hinkokocevar/work/genicam/autosave/include   -I/home/hinkokocevar/work/genicam/sncseq/include   -I/home/hinkokocevar/work/genicam/sscan/include   -I/home/hinkokocevar/work/genicam/calc/include   -I../../../include   -I/home/hinkokocevar/work/genicam/busy/include                    -c testEpics_registerRecordDeviceDriver.cpp
/usr/bin/g++ -o testEpics -Wl,-Bstatic -L/home/hinkokocevar/work/genicam/asyn/lib/linux-x86_64 -L/home/hinkokocevar/work/genicam/calc/lib/linux-x86_64 -L/home/hinkokocevar/work/genicam/epics-base/lib/linux-x86_64 -L/home/hinkokocevar/work/genicam/sscan/lib/linux-x86_64 -Wl,-rpath,/home/hinkokocevar/work/genicam/asyn/lib/linux-x86_64 -Wl,-rpath,/home/hinkokocevar/work/genicam/calc/lib/linux-x86_64 -Wl,-rpath,/home/hinkokocevar/work/genicam/epics-base/lib/linux-x86_64 -Wl,-rpath,/home/hinkokocevar/work/genicam/sscan/lib/linux-x86_64           -rdynamic -m64         testEpics_registerRecordDeviceDriver.o testEpicsMain.o    -ltestEpicsSupport -ltestSupport -lasyn -lcalc -lsscan -ldbRecStd -ldbCore -lca -lCom -Wl,-Bdynamic  -lpthread   -lreadline -lm -lrt -ldl -lgcc
/home/hinkokocevar/work/genicam/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_entry_editSseq_0_newCommand':
editSseq.c:(.text+0x7e): undefined reference to `seq_pvGetTmo'
editSseq.c:(.text+0x9c): undefined reference to `seq_pvGetTmo'
editSseq.c:(.text+0xba): undefined reference to `seq_pvGetTmo'
editSseq.c:(.text+0xd8): undefined reference to `seq_pvGetTmo'
editSseq.c:(.text+0x100): undefined reference to `seq_pvGetTmo'
/home/hinkokocevar/work/genicam/calc/lib/linux-x86_64/libcalc.a(editSseq.o):editSseq.c:(.text+0x11e): more undefined references to `seq_pvGetTmo' follow
/home/hinkokocevar/work/genicam/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_entry_editSseq_0_newCommand':
editSseq.c:(.text+0x154): undefined reference to `seq_pvPutTmo'
/home/hinkokocevar/work/genicam/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_entry_editSseq_0_newRecordName':
editSseq.c:(.text+0x2ec): undefined reference to `seq_pvPutTmo'
/home/hinkokocevar/work/genicam/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `editSseqRegistrar':
editSseq.c:(.text+0x385): undefined reference to `seqRegisterSequencerCommands'
/home/hinkokocevar/work/genicam/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_action_editSseq_0_waitForCmnd':
editSseq.c:(.text+0x3eb): undefined reference to `seq_pvPutTmo'
editSseq.c:(.text+0x40b): undefined reference to `seq_pvPutTmo'
/home/hinkokocevar/work/genicam/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_action_editSseq_0_newRecordName':
editSseq.c:(.text+0x486): undefined reference to `seq_pvAssign'
editSseq.c:(.text+0x49d): undefined reference to `seq_pvGetTmo'
editSseq.c:(.text+0x56b): undefined reference to `seq_pvAssign'
editSseq.c:(.text+0x5c9): undefined reference to `seq_pvAssign'
editSseq.c:(.text+0x621): undefined reference to `seq_pvAssign'
editSseq.c:(.text+0x679): undefined reference to `seq_pvAssign'
editSseq.c:(.text+0x6e8): undefined reference to `seq_pvAssign'
/home/hinkokocevar/work/genicam/calc/lib/linux-x86_64/libcalc.a(editSseq.o):editSseq.c:(.text+0x74a): more undefined references to `seq_pvAssign' follow
/home/hinkokocevar/work/genicam/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_entry_editSseq_0_waitForCmnd':
editSseq.c:(.text+0x7b9): undefined reference to `seq_efClear'
/home/hinkokocevar/work/genicam/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_action_editSseq_0_init':
editSseq.c:(.text+0x833): undefined reference to `seq_pvPutTmo'
editSseq.c:(.text+0x853): undefined reference to `seq_pvPutTmo'
/home/hinkokocevar/work/genicam/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_event_editSseq_0_waitForCmnd':
editSseq.c:(.text+0x883): undefined reference to `seq_efTestAndClear'
editSseq.c:(.text+0x8b1): undefined reference to `seq_efTestAndClear'
/home/hinkokocevar/work/genicam/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `reconcilePVs.constprop.6':
editSseq.c:(.text+0xab7): undefined reference to `seq_pvPut'
/home/hinkokocevar/work/genicam/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_action_editSseq_0_newCommand':
editSseq.c:(.text+0xc9f): undefined reference to `seq_pvPutTmo'
editSseq.c:(.text+0xe5a): undefined reference to `seq_pvPutTmo'
editSseq.c:(.text+0xe76): undefined reference to `seq_pvPutTmo'
editSseq.c:(.text+0xf49): undefined reference to `seq_pvPutTmo'
editSseq.c:(.text+0xf6c): undefined reference to `seq_pvPutTmo'
/home/hinkokocevar/work/genicam/calc/lib/linux-x86_64/libcalc.a(editSseq.o):editSseq.c:(.text+0xfe8): more undefined references to `seq_pvPutTmo' follow
/home/hinkokocevar/work/genicam/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_action_editSseq_0_newCommand':
editSseq.c:(.text+0x3966): undefined reference to `seq_pvPut'
editSseq.c:(.text+0x39b6): undefined reference to `seq_pvPut'
editSseq.c:(.text+0x3a06): undefined reference to `seq_pvPut'
editSseq.c:(.text+0x3a56): undefined reference to `seq_pvPut'
editSseq.c:(.text+0x3aa6): undefined reference to `seq_pvPut'
/home/hinkokocevar/work/genicam/calc/lib/linux-x86_64/libcalc.a(editSseq.o):editSseq.c:(.text+0x3af6): more undefined references to `seq_pvPut' follow
/home/hinkokocevar/work/genicam/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_entry_editSseq_0_newCommand':
editSseq.c:(.text+0x175): undefined reference to `seq_pvPutTmo'
/home/hinkokocevar/work/genicam/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `editSseqRegistrar':
editSseq.c:(.text+0x395): undefined reference to `seqRegisterSequencerProgram'
/home/hinkokocevar/work/genicam/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_action_editSseq_0_waitForCmnd':
editSseq.c:(.text+0x42c): undefined reference to `seq_pvPutTmo'
/home/hinkokocevar/work/genicam/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_action_editSseq_0_init':
editSseq.c:(.text+0x861): undefined reference to `seq_efClear'
/home/hinkokocevar/work/genicam/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_action_editSseq_0_newCommand':
editSseq.c:(.text+0xcd0): undefined reference to `seq_pvPutTmo'
collect2: error: ld returned 1 exit status
/home/hinkokocevar/work/genicam/epics-base/configure/RULES_BUILD:212: recipe for target 'testEpics' failed
make[2]: *** [testEpics] Error 1
make[2]: Leaving directory '/home/hinkokocevar/work/genicam/asyn/testEpicsApp/src/O.linux-x86_64'
/home/hinkokocevar/work/genicam/epics-base/configure/RULES_ARCHS:58: recipe for target 'install.linux-x86_64' failed
make[1]: *** [install.linux-x86_64] Error 2
make[1]: Leaving directory '/home/hinkokocevar/work/genicam/asyn/testEpicsApp/src'
/home/hinkokocevar/work/genicam/epics-base/configure/RULES_DIRS:84: recipe for target 'src.install' failed
make: *** [src.install] Error 2
make: Leaving directory '/home/hinkokocevar/work/genicam/asyn/testEpicsApp'

```