### PR TITLE
Take connect timestamp after connection attempt

### DIFF
--- a/asyn/asynDriver/asynManager.c
+++ b/asyn/asynDriver/asynManager.c
@@ -695,11 +695,11 @@ static BOOL autoConnectDevice(port *pport,device *pdevice)
         epicsTimeGetCurrent(&now);
         if(epicsTimeDiffInSeconds(
              &now,&pport->dpc.lastConnectDisconnect) < 2.0) return FALSE;
-        epicsTimeGetCurrent(&pport->dpc.lastConnectDisconnect);
         pport->dpc.autoConnectActive = TRUE;
         epicsMutexUnlock(pport->asynManagerLock);
         connectAttempt(&pport->dpc);
         epicsMutexMustLock(pport->asynManagerLock);
+        epicsTimeGetCurrent(&pport->dpc.lastConnectDisconnect);
         pport->dpc.autoConnectActive = FALSE;
     }
     if(!pport->dpc.connected) return FALSE;
@@ -712,11 +712,11 @@ static BOOL autoConnectDevice(port *pport,device *pdevice)
         epicsTimeGetCurrent(&now);
         if(epicsTimeDiffInSeconds(
             &now,&pdevice->dpc.lastConnectDisconnect) < 2.0) return FALSE;
-        epicsTimeGetCurrent(&pdevice->dpc.lastConnectDisconnect);
         pdevice->dpc.autoConnectActive = TRUE;
         epicsMutexUnlock(pport->asynManagerLock);
         connectAttempt(&pdevice->dpc);
         epicsMutexMustLock(pport->asynManagerLock);
+        epicsTimeGetCurrent(&pdevice->dpc.lastConnectDisconnect);
         pdevice->dpc.autoConnectActive = FALSE;
     }
     return pdevice->dpc.connected;


### PR DESCRIPTION
autoConnectDevice() has a built-in protection that forces at least 2
seconds between connection attempts. However, with the current implementation
the timestamp is taken _before_ starting the connection, so if the connection
attempt takes about 2 seconds (or more) to timeout then that 2 second
'do-not-connect' window has already expired (or about to expire) by the
time connectAttempt() returns. Better to take the timestamp _after_
connectAttempt() returns.