### PR TITLE
Added free() statement

### DIFF
--- a/asyn/drvAsynSerial/drvAsynIPPort.c
+++ b/asyn/drvAsynSerial/drvAsynIPPort.c
@@ -875,6 +875,7 @@ ttyCleanup(ttyController_t *tty)
             epicsSocketDestroy(tty->fd);
         free(tty->portName);
         free(tty->IPDeviceName);
+        free(tty->IPHostName);
         free(tty);
     }
 }


### PR DESCRIPTION
ttyCleanup() does not free all of the allocated strings, so there is a tiny memory leak there.