### PR TITLE
WIP - PVI

### DIFF
--- a/asyn/Makefile
+++ b/asyn/Makefile
@@ -132,6 +132,7 @@ ifeq ($(EPICS_LIBCOM_ONLY),YES)
 endif
 INC += asynParamType.h
 INC += paramErrors.h
+INC += asynParamSet.h
 INC += asynPortDriver.h
 asyn_SRCS += paramVal.cpp
 asyn_SRCS += asynPortDriver.cpp

--- a/asyn/asynPortDriver/asynParamSet.h
+++ b/asyn/asynPortDriver/asynParamSet.h
@@ -1,0 +1,34 @@
+#ifndef AsynParamSet_H
+#define AsynParamSet_H
+
+#include <vector>
+
+#include "asynParamType.h"
+
+struct asynParam {
+    const char* name;
+    asynParamType type;
+    int* index;
+};
+
+class asynParamSet {
+public:
+    std::vector<asynParam> getParamDefinitions() {
+        return paramDefinitions;
+    }
+
+protected:
+    void add(const char* name, asynParamType type, int* index) {
+        asynParam param;
+        param.name = name;
+        param.type = type;
+        param.index = index;
+
+        this->paramDefinitions.push_back(param);
+    }
+
+private:
+    std::vector<asynParam> paramDefinitions;
+};
+
+#endif  // AsynParamSet_H

--- a/asyn/asynPortDriver/asynPortDriver.cpp
+++ b/asyn/asynPortDriver/asynPortDriver.cpp
@@ -3626,6 +3626,15 @@ static asynDrvUser ifaceDrvUser = {
     drvUserDestroy
 };
 
+asynPortDriver::asynPortDriver(asynParamSet* paramSet,
+                               const char *portNameIn, int maxAddrIn, int interfaceMask, int interruptMask,
+                               int asynFlags, int autoConnect, int priority, int stackSize):
+    paramSet(paramSet)
+{
+    initialize(portNameIn, maxAddrIn, interfaceMask, interruptMask, asynFlags,
+               autoConnect, priority, stackSize);
+    createParams();
+}
 
 
 /** Constructor for the asynPortDriver class.
@@ -3790,6 +3799,19 @@ void asynPortDriver::initialize(const char *portNameIn, int maxAddrIn, int inter
 
     /* Create a thread that waits for interruptAccept and then does all the callbacks once. */
     cbThread = new callbackThread(this);
+}
+
+/** Create any parameters defined in the asynParamSet, if there are any */
+asynStatus asynPortDriver::createParams()
+{
+    asynStatus status;
+    std::vector<asynParam> paramDefinitions = paramSet->getParamDefinitions();
+    for (std::vector<asynParam>::iterator it = paramDefinitions.begin(); it != paramDefinitions.end(); ++it) {
+        status = createParam(it->name, it->type, it->index);
+        if (status) return asynError;
+    }
+
+    return asynSuccess;
 }
 
 /** Destructor for asynPortDriver class; frees resources allocated when port driver is created. */

--- a/asyn/asynPortDriver/asynPortDriver.h
+++ b/asyn/asynPortDriver/asynPortDriver.h
@@ -238,6 +238,18 @@ private:
     epicsEvent doneEvent;
 };
 
+/** Utility function that returns a pointer to an asynPortDriver derived class object from its name */
+template <class T> T* findDerivedAsynPortDriver(const char* portName)
+{
+  // findAsynPortDriver returns a void pointer that was cast from an asynPortDriver pointer
+  asynPortDriver* apd = (asynPortDriver*) findAsynPortDriver(portName);
+  if (!apd) return NULL;
+
+  // Downcast asynPortDriver pointer to T pointer - this requires pointer offsetting
+  T* pC = dynamic_cast<T*>(apd);
+  return pC;
+}
+
 #endif /* cplusplus */
 
 #endif

--- a/asyn/asynPortDriver/asynPortDriver.h
+++ b/asyn/asynPortDriver/asynPortDriver.h
@@ -9,6 +9,7 @@
 #include <epicsThread.h>
 
 #include <asynStandardInterfaces.h>
+#include <asynParamSet.h>
 #include <asynParamType.h>
 #include <paramErrors.h>
 
@@ -43,6 +44,9 @@ class callbackThread;
   * with standard asyn interfaces and a parameter library. */
 class epicsShareClass asynPortDriver {
 public:
+    asynPortDriver(asynParamSet* paramSet,
+                   const char *portName, int maxAddr, int interfaceMask, int interruptMask,
+                   int asynFlags, int autoConnect, int priority, int stackSize);
     asynPortDriver(const char *portName, int maxAddr, int interfaceMask, int interruptMask,
                    int asynFlags, int autoConnect, int priority, int stackSize);
     asynPortDriver(const char *portName, int maxAddr, int paramTableSize, int interfaceMask, int interruptMask,
@@ -129,6 +133,7 @@ public:
 
     virtual asynStatus createParam(          const char *name, asynParamType type, int *index);
     virtual asynStatus createParam(int list, const char *name, asynParamType type, int *index);
+    virtual asynStatus createParams();
     virtual asynStatus getNumParams(          int *numParams);
     virtual asynStatus getNumParams(int list, int *numParams);
     virtual asynStatus findParam(          const char *name, int *index);
@@ -199,6 +204,7 @@ public:
     void callbackTask();
 
 protected:
+    asynParamSet* paramSet;
     void initialize(const char *portNameIn, int maxAddrIn, int interfaceMask, int interruptMask, int asynFlags,
                     int autoConnect, int priority, int stackSize);
     asynUser *pasynUserSelf;    /**< asynUser connected to ourselves for asynTrace */


### PR DESCRIPTION
Creates new asynParam and asynParamSet classes to store the parameter definitions separately from the driver class and updates asynPortDriver to have an asynParamSet and call createParam on all the parameters stored within it from child classes. There is a new asynPortDriver constructor that takes a asynParamSet and calls createParams.

For full context see: https://github.com/areaDetector/ADCore/issues/446 

