### PR TITLE
Makefile(s): Decouple CALC and SSCAN

### DIFF
--- a/asyn/Makefile
+++ b/asyn/Makefile
@@ -194,11 +194,12 @@ ifneq ($(EPICS_LIBCOM_ONLY),YES)
   # do we have EPICS calc module (scalcout etc.)
   # applications should include asynCalc.dbd as well as asyn.dbd if support is needed
   ifdef CALC
-  ifdef SSCAN
     USR_CFLAGS += -DHAVE_CALCMOD
-    ASYN_LIBS += calc sscan
+    ASYN_LIBS += calc
     DBD += asynCalc.dbd
   endif
+  ifdef SSCAN
+    ASYN_LIBS += sscan
   endif
 
   ifdef HAVE_DEVINT64

--- a/testEpicsApp/src/Makefile
+++ b/testEpicsApp/src/Makefile
@@ -21,7 +21,10 @@ testEpicsSupport_SRCS += int32Driver.c
 testEpicsSupport_SRCS += uint32DigitalDriver.c
 testEpicsSupport_LIBS += asyn
 ifdef CALC
-testEpicsSupport_LIBS += calc sscan
+testEpicsSupport_LIBS += calc
+endif
+ifdef SSCAN
+testEpicsSupport_LIBS += calc
 endif
 ifdef SNCSEQ
 testEpicsSupport_LIBS += seq pv
@@ -38,7 +41,10 @@ testEpics_LIBS += testEpicsSupport
 testEpics_LIBS += testSupport
 testEpics_LIBS += asyn
 ifdef CALC
-testEpics_LIBS += calc sscan
+testEpics_LIBS += calc
+endif
+ifdef SSCAN
+testEpics_LIBS += sscan
 endif
 ifdef SNCSEQ
 testEpics_LIBS += seq pv


### PR DESCRIPTION
The current Makefile(s) failed to build a version, where CALC was
defined, but not SSCAN.
Decouple those 2 in the Makefiles.