### PR TITLE
Fix so reuseport

### DIFF
--- a/asyn/drvAsynSerial/drvAsynIPPort.c
+++ b/asyn/drvAsynSerial/drvAsynIPPort.c
@@ -85,8 +85,9 @@
 # endif
 #endif
 
-/* On most systems we use SO_REUSEPORT but RTEMS and Windows don't have SO_REUSEPORT, use SO_REUSEADDR instead */
-#if defined(__rtems__) || defined(_WIN32)
+/* If SO_REUSEPORT is not defined then use SO_REUSEADDR instead.  
+   It is not defined on RTEMS, Windows and older Linux versions. */
+#ifndef SO_REUSEPORT
 # define USE_SO_REUSEADDR
 #endif
 


### PR DESCRIPTION
This fixes the problem that SO_REUSEPORT is not supported on older versions of Linux.  Previously we used SO_REUSEADDR instead of SO_REUSEPORT on RTEMS and Windows.  This changes the logic to use SO_REUSEADDR instead of SO_REUSEPORT whenever SO_REUSEPORT is undefined.
