### PR TITLE
Replace shareLib.h with ASYN_API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,15 @@ jobs:
 #  - env: SET=base7 BCFG=static-debug
 #    compiler: vs2017
 #    os: windows
+  - env: SET=base3-14
+    compiler: vs2017
+    os: windows
+  - env: SET=base3-14 BCFG=static
+    compiler: vs2017
+    os: windows
+  - env: SET=base3-14 BCFG=debug
+    compiler: vs2017
+    os: windows
 
 # Older Base releases
   - env: SET=base3-15

--- a/asyn/Makefile
+++ b/asyn/Makefile
@@ -38,6 +38,7 @@ ifeq ($(TIRPC),YES)
 endif
 
 SRC_DIRS += $(ASYN)/asynDriver
+INC += asynAPI.h
 INC += asynDriver.h
 INC += epicsInterruptibleSyscall.h
 asyn_SRCS += asynManager.c
@@ -353,4 +354,10 @@ else
 	$(PERL) $(TOOLS)/makeIncludeDbd.pl $(devEpics_DBD) $(notdir $@)
 	@$(MV) $(notdir $@) $@
 endif
+
+$(LIB_PREFIX)asyn$(LIB_SUFFIX): USR_CPPFLAGS += -DBUILDING_asyn_API
+ifeq ($(SHARED_LIBRARIES),YES)
+  $(SHRLIB_PREFIX)asyn$(SHRLIB_SUFFIX): USR_CPPFLAGS += -DBUILDING_asyn_API
+endif
+
 

--- a/asyn/Makefile
+++ b/asyn/Makefile
@@ -355,9 +355,4 @@ else
 	@$(MV) $(notdir $@) $@
 endif
 
-$(LIB_PREFIX)asyn$(LIB_SUFFIX): USR_CPPFLAGS += -DBUILDING_asyn_API
-ifeq ($(SHARED_LIBRARIES),YES)
-  $(SHRLIB_PREFIX)asyn$(SHRLIB_SUFFIX): USR_CPPFLAGS += -DBUILDING_asyn_API
-endif
-
-
+USR_CPPFLAGS += -DBUILDING_asyn_API

--- a/asyn/asynDriver/asynAPI.h
+++ b/asyn/asynDriver/asynAPI.h
@@ -1,0 +1,33 @@
+/* This is a generated file, do not edit! */
+
+#ifndef INC_asynAPI_H
+#define INC_asynAPI_H
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+
+#  if !defined(epicsStdCall)
+#    define epicsStdCall __stdcall
+#  endif
+
+#  if defined(BUILDING_asyn_API) && defined(EPICS_BUILD_DLL)
+/* Building library as dll */
+#    define ASYN_API __declspec(dllexport)
+#  elif !defined(BUILDING_asyn_API) && defined(EPICS_CALL_DLL)
+/* Calling library in dll form */
+#    define ASYN_API __declspec(dllimport)
+#  endif
+
+#elif __GNUC__ >= 4
+#  define ASYN_API __attribute__ ((visibility("default")))
+#endif
+
+#if !defined(ASYN_API)
+#  define ASYN_API
+#endif
+
+#if !defined(epicsStdCall)
+#  define epicsStdCall
+#endif
+
+#endif /* INC_asynAPI_H */
+

--- a/asyn/asynDriver/asynAPI.h
+++ b/asyn/asynDriver/asynAPI.h
@@ -1,7 +1,21 @@
-/* This is a generated file, do not edit! */
-
 #ifndef INC_asynAPI_H
 #define INC_asynAPI_H
+
+#include <epicsVersion.h>
+
+#ifndef VERSION_INT
+//! Construct version number constant.
+#  define VERSION_INT(V,R,M,P) ( ((V)<<24) | ((R)<<16) | ((M)<<8) | (P))
+#endif
+
+#ifndef EPICS_VERSION_INT
+#  define EPICS_VERSION_INT VERSION_INT(EPICS_VERSION, EPICS_REVISION, EPICS_MODIFICATION, EPICS_PATCH_LEVEL)
+#endif
+
+#if defined(_WIN32) && EPICS_VERSION_INT<VERSION_INT(3,15,0,0) && !defined(EPICS_DLL_NO)
+#    define EPICS_BUILD_DLL
+#    define EPICS_CALL_DLL
+#endif
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 

--- a/asyn/asynDriver/asynDriver.h
+++ b/asyn/asynDriver/asynDriver.h
@@ -18,8 +18,8 @@
 #include <epicsStdio.h>
 #include <epicsTime.h>
 #include <ellLib.h>
-#include <shareLib.h>
 #include <epicsVersion.h>
+#include <asynAPI.h>
 
 /* Version number names similar to those provide by base
  * These macros are always numeric */
@@ -184,7 +184,7 @@ typedef struct asynManager {
 
     const char *(*strStatus)(asynStatus status);
 }asynManager;
-epicsShareExtern asynManager *pasynManager;
+ASYN_API extern asynManager *pasynManager;
 
 /* Interface supported by ALL asyn drivers*/
 #define asynCommonType "asynCommon"
@@ -273,7 +273,7 @@ typedef struct asynTrace {
                     const char *buffer, size_t len,const char *file, int line, const char *pformat, va_list pvar) EPICS_PRINTF_STYLE(7,0);
 #endif
 }asynTrace;
-epicsShareExtern asynTrace *pasynTrace;
+ASYN_API extern asynTrace *pasynTrace;
 
 #if (defined(__STDC_VERSION__) && __STDC_VERSION__>=199901L) || defined(_WIN32)
 #define asynPrint(pasynUser,reason, ...) \

--- a/asyn/asynDriver/asynManager.c
+++ b/asyn/asynDriver/asynManager.c
@@ -386,7 +386,7 @@ static asynManager manager = {
     setTimeStamp,
     strStatus
 };
-epicsShareDef asynManager *pasynManager = &manager;
+asynManager *pasynManager = &manager;
 
 /* asynTrace methods */
 static asynStatus traceLock(asynUser *pasynUser);
@@ -439,7 +439,7 @@ static asynTrace asynTraceManager = {
     traceVprintIO,
     traceVprintIOSource
 };
-epicsShareDef asynTrace *pasynTrace = &asynTraceManager;
+asynTrace *pasynTrace = &asynTraceManager;
 
 /*internal methods */
 static void tracePvtInit(tracePvt *ptracePvt)

--- a/asyn/asynGpib/asynGpib.c
+++ b/asyn/asynGpib/asynGpib.c
@@ -139,7 +139,7 @@ static asynGpib gpib = {
 /*asynInt32Base implements all asynInt32 methods*/
 static asynInt32 int32 = {0,0,0,0,0};
 
-epicsShareDef asynGpib *pasynGpib = &gpib;
+asynGpib *pasynGpib = &gpib;
 
 /*internal methods */
 static void gpibInit(void)

--- a/asyn/asynGpib/asynGpibDriver.h
+++ b/asyn/asynGpib/asynGpibDriver.h
@@ -10,7 +10,6 @@
 
 #ifndef INCasynGpibh
 #define INCasynGpibh
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -61,7 +60,7 @@ struct asynGpib{
         unsigned int priority, unsigned int stackSize);
     void (*srqHappened)(void *asynGpibPvt);
 };
-epicsShareExtern asynGpib *pasynGpib;
+ASYN_API extern asynGpib *pasynGpib;
 
 struct asynGpibPort {
     /*asynCommon methods */

--- a/asyn/asynPortClient/asynPortClient.cpp
+++ b/asyn/asynPortClient/asynPortClient.cpp
@@ -14,8 +14,6 @@
 #include <stdexcept>
 #include <epicsThread.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynPortDriver.h"
 #include "asynPortClient.h"
 

--- a/asyn/asynPortClient/asynPortClient.h
+++ b/asyn/asynPortClient/asynPortClient.h
@@ -42,7 +42,7 @@
 
 /** Base class for asyn port clients; handles most of the bookkeeping for writing an asyn port client
   * with standard asyn interfaces. */
-class epicsShareClass asynParamClient {
+class ASYN_API asynParamClient {
 public:
     asynParamClient(const char *portName, int addr, const char* asynInterfaceType, const char *drvInfo, double timeout);
     virtual ~asynParamClient();
@@ -71,7 +71,7 @@ protected:
 
 
 /** Class for asyn port clients to communicate on the asynInt32 interface */
-class epicsShareClass asynInt32Client : public asynParamClient {
+class ASYN_API asynInt32Client : public asynParamClient {
 public:
     /** Constructor for asynInt32Client class
       * \param[in] portName  The name of the asyn port to connect to
@@ -128,7 +128,7 @@ private:
 
 
 /** Class for asyn port clients to communicate on the asynUInt32Digital interface */
-class epicsShareClass asynUInt32DigitalClient : public asynParamClient {
+class ASYN_API asynUInt32DigitalClient : public asynParamClient {
 public:
     /** Constructor for asynUInt32DigitalClient class
       * \param[in] portName  The name of the asyn port to connect to
@@ -196,7 +196,7 @@ private:
 
 
 /** Class for asyn port clients to communicate on the asynFloat64 interface */
-class epicsShareClass asynFloat64Client : public asynParamClient {
+class ASYN_API asynFloat64Client : public asynParamClient {
 public:
     /** Constructor for asynFloat64Client class
       * \param[in] portName  The name of the asyn port to connect to
@@ -244,7 +244,7 @@ private:
 
 
 /** Class for asyn port clients to communicate on the asynOctet interface */
-class epicsShareClass asynOctetClient : public asynParamClient {
+class ASYN_API asynOctetClient : public asynParamClient {
 public:
     /** Constructor for asynOctetClient class
       * \param[in] portName  The name of the asyn port to connect to
@@ -347,7 +347,7 @@ private:
 
 
 /** Class for asyn port clients to communicate on the asynInt8Array interface */
-class epicsShareClass asynInt8ArrayClient : public asynParamClient {
+class ASYN_API asynInt8ArrayClient : public asynParamClient {
 public:
     /** Constructor for asynInt8Array class
       * \param[in] portName  The name of the asyn port to connect to
@@ -398,7 +398,7 @@ private:
 
 
 /** Class for asyn port clients to communicate on the asynInt16Array interface */
-class epicsShareClass asynInt16ArrayClient : public asynParamClient {
+class ASYN_API asynInt16ArrayClient : public asynParamClient {
 public:
     /** Constructor for asynInt16Array class
       * \param[in] portName  The name of the asyn port to connect to
@@ -449,7 +449,7 @@ private:
 
 
 /** Class for asyn port clients to communicate on the asynInt32Array interface */
-class epicsShareClass asynInt32ArrayClient : public asynParamClient {
+class ASYN_API asynInt32ArrayClient : public asynParamClient {
 public:
     /** Constructor for asynInt32Array class
       * \param[in] portName  The name of the asyn port to connect to
@@ -500,7 +500,7 @@ private:
 
 
 /** Class for asyn port clients to communicate on the asynFloat32Array interface */
-class epicsShareClass asynFloat32ArrayClient : public asynParamClient {
+class ASYN_API asynFloat32ArrayClient : public asynParamClient {
 public:
     /** Constructor for asynFloat32Array class
       * \param[in] portName  The name of the asyn port to connect to
@@ -551,7 +551,7 @@ private:
 
 
 /** Class for asyn port clients to communicate on the asynFloat64Array interface */
-class epicsShareClass asynFloat64ArrayClient : public asynParamClient {
+class ASYN_API asynFloat64ArrayClient : public asynParamClient {
 public:
     /** Constructor for asynFloat64Array class
       * \param[in] portName  The name of the asyn port to connect to
@@ -602,7 +602,7 @@ private:
 
 
 /** Class for asyn port clients to communicate on the asynGenericPointer interface */
-class epicsShareClass asynGenericPointerClient : public asynParamClient {
+class ASYN_API asynGenericPointerClient : public asynParamClient {
 public:
     /** Constructor for asynGenericPointer class
       * \param[in] portName  The name of the asyn port to connect to
@@ -650,7 +650,7 @@ private:
 
 
 /** Class for asyn port clients to communicate on the asynOption interface */
-class epicsShareClass asynOptionClient : public asynParamClient {
+class ASYN_API asynOptionClient : public asynParamClient {
 public:
     /** Constructor for asynOption class
       * \param[in] portName  The name of the asyn port to connect to
@@ -693,7 +693,7 @@ private:
 
 
 /** Class for asyn port clients to communicate on the asynEnum interface */
-class epicsShareClass asynEnumClient : public asynParamClient {
+class ASYN_API asynEnumClient : public asynParamClient {
 public:
     /** Constructor for asynEnum class
       * \param[in] portName  The name of the asyn port to connect to
@@ -740,7 +740,7 @@ private:
 
 
 /** Class for asyn port clients to communicate on the asynCommon interface */
-class epicsShareClass asynCommonClient : public asynParamClient {
+class ASYN_API asynCommonClient : public asynParamClient {
 public:
     /** Constructor for asynCommon class
       * \param[in] portName  The name of the asyn port to connect to
@@ -784,7 +784,7 @@ private:
 
 typedef std::map<std::string, asynParamClient*> paramMap_t;
 
-class epicsShareClass asynPortClient {
+class ASYN_API asynPortClient {
 public:
     asynPortClient(const char *portName, double timeout=1.0);
     virtual ~asynPortClient();

--- a/asyn/asynPortDriver/asynPortDriver.cpp
+++ b/asyn/asynPortDriver/asynPortDriver.cpp
@@ -27,8 +27,6 @@
     #include <dbAccess.h>
 #endif
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "paramVal.h"
 #include "paramErrors.h"
 #include "asynParamType.h"

--- a/asyn/asynPortDriver/asynPortDriver.h
+++ b/asyn/asynPortDriver/asynPortDriver.h
@@ -15,7 +15,7 @@
 
 class paramList;
 
-epicsShareFunc void* findAsynPortDriver(const char *portName);
+ASYN_API void* findAsynPortDriver(const char *portName);
 typedef void (*userTimeStampFunction)(void *userPvt, epicsTimeStamp *pTimeStamp);
 
 #ifdef __cplusplus
@@ -42,7 +42,7 @@ class callbackThread;
 
 /** Base class for asyn port drivers; handles most of the bookkeeping for writing an asyn port driver
   * with standard asyn interfaces and a parameter library. */
-class epicsShareClass asynPortDriver {
+class ASYN_API asynPortDriver {
 public:
     asynPortDriver(asynParamSet* paramSet,
                    const char *portName, int maxAddr, int interfaceMask, int interruptMask,

--- a/asyn/devEpics/asynEpicsUtils.c
+++ b/asyn/devEpics/asynEpicsUtils.c
@@ -22,8 +22,6 @@
 #include <epicsString.h>
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynEpicsUtils.h"
 
 static asynStatus parseLink(asynUser *pasynUser, DBLINK *plink,
@@ -40,7 +38,7 @@ static asynEpicsUtils utils = {
     parseLink,parseLinkMask,parseLinkFree,asynStatusToEpicsAlarm
 };
 
-epicsShareDef asynEpicsUtils *pasynEpicsUtils = &utils;
+asynEpicsUtils *pasynEpicsUtils = &utils;
 
 /* parseLink syntax is:
    VME_IO "C<ignore> S<addr> @<portName> userParams

--- a/asyn/devEpics/asynEpicsUtils.h
+++ b/asyn/devEpics/asynEpicsUtils.h
@@ -13,7 +13,6 @@
 #define asynEpicsUtilsH
 
 #include <link.h>
-#include <shareLib.h>
 #include <epicsTypes.h>
 #include <alarm.h>
 #include "asynDriver.h"
@@ -33,7 +32,7 @@ typedef struct asynEpicsUtils {
                 epicsAlarmCondition defaultStat, epicsAlarmCondition *pStat,
                 epicsAlarmSeverity defaultSevr, epicsAlarmSeverity *pSevr);
 } asynEpicsUtils;
-epicsShareExtern asynEpicsUtils *pasynEpicsUtils;
+ASYN_API extern asynEpicsUtils *pasynEpicsUtils;
 
 #ifdef __cplusplus
 }

--- a/asyn/devGpib/devCommonGpib.c
+++ b/asyn/devGpib/devCommonGpib.c
@@ -33,8 +33,6 @@
 #include <errlog.h>
 #include <menuFtype.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynGpibDriver.h"
 #include "devSupportGpib.h"

--- a/asyn/devGpib/devCommonGpib.h
+++ b/asyn/devGpib/devCommonGpib.h
@@ -18,40 +18,39 @@
 #define INCdevCommonGpibh
 
 #include <devSupportGpib.h>
-#include "shareLib.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif  /* __cplusplus */
 
-epicsShareFunc long  devGpib_initAi(struct aiRecord * pai);
-epicsShareFunc long  devGpib_readAi(struct aiRecord * pai);
-epicsShareFunc long  devGpib_initAo(struct aoRecord * pao);
-epicsShareFunc long  devGpib_writeAo(struct aoRecord * pao);
-epicsShareFunc long  devGpib_initBi(struct biRecord * pbi);
-epicsShareFunc long  devGpib_readBi(struct biRecord * pbi);
-epicsShareFunc long  devGpib_initBo(struct boRecord * pbo);
-epicsShareFunc long  devGpib_writeBo(struct boRecord * pbo);
-epicsShareFunc long  devGpib_initEv(struct eventRecord * pev);
-epicsShareFunc long  devGpib_readEv(struct eventRecord * pev);
-epicsShareFunc long  devGpib_initLi(struct longinRecord * pli);
-epicsShareFunc long  devGpib_readLi(struct longinRecord * pli);
-epicsShareFunc long  devGpib_initLo(struct longoutRecord * plo);
-epicsShareFunc long  devGpib_writeLo(struct longoutRecord * plo);
-epicsShareFunc long  devGpib_initMbbi(struct mbbiRecord * pmbbi);
-epicsShareFunc long  devGpib_readMbbi(struct mbbiRecord * pmbbi);
-epicsShareFunc long  devGpib_initMbbiDirect(struct mbbiDirectRecord * pmbbiDirect);
-epicsShareFunc long  devGpib_readMbbiDirect(struct mbbiDirectRecord * pmbbiDirect);
-epicsShareFunc long  devGpib_initMbbo(struct mbboRecord * pmbbo);
-epicsShareFunc long  devGpib_writeMbbo(struct mbboRecord * pmbbo);
-epicsShareFunc long  devGpib_initMbboDirect(struct mbboDirectRecord * pmbboDirect);
-epicsShareFunc long  devGpib_writeMbboDirect(struct mbboDirectRecord * pmbboDirect);
-epicsShareFunc long  devGpib_initSi(struct stringinRecord * psi);
-epicsShareFunc long  devGpib_readSi(struct stringinRecord * psi);
-epicsShareFunc long  devGpib_initSo(struct stringoutRecord * pso);
-epicsShareFunc long  devGpib_writeSo(struct stringoutRecord * pso);
-epicsShareFunc long  devGpib_initWf(struct waveformRecord * pwf);
-epicsShareFunc long  devGpib_readWf(struct waveformRecord * pwf);
+ASYN_API long  devGpib_initAi(struct aiRecord * pai);
+ASYN_API long  devGpib_readAi(struct aiRecord * pai);
+ASYN_API long  devGpib_initAo(struct aoRecord * pao);
+ASYN_API long  devGpib_writeAo(struct aoRecord * pao);
+ASYN_API long  devGpib_initBi(struct biRecord * pbi);
+ASYN_API long  devGpib_readBi(struct biRecord * pbi);
+ASYN_API long  devGpib_initBo(struct boRecord * pbo);
+ASYN_API long  devGpib_writeBo(struct boRecord * pbo);
+ASYN_API long  devGpib_initEv(struct eventRecord * pev);
+ASYN_API long  devGpib_readEv(struct eventRecord * pev);
+ASYN_API long  devGpib_initLi(struct longinRecord * pli);
+ASYN_API long  devGpib_readLi(struct longinRecord * pli);
+ASYN_API long  devGpib_initLo(struct longoutRecord * plo);
+ASYN_API long  devGpib_writeLo(struct longoutRecord * plo);
+ASYN_API long  devGpib_initMbbi(struct mbbiRecord * pmbbi);
+ASYN_API long  devGpib_readMbbi(struct mbbiRecord * pmbbi);
+ASYN_API long  devGpib_initMbbiDirect(struct mbbiDirectRecord * pmbbiDirect);
+ASYN_API long  devGpib_readMbbiDirect(struct mbbiDirectRecord * pmbbiDirect);
+ASYN_API long  devGpib_initMbbo(struct mbboRecord * pmbbo);
+ASYN_API long  devGpib_writeMbbo(struct mbboRecord * pmbbo);
+ASYN_API long  devGpib_initMbboDirect(struct mbboDirectRecord * pmbboDirect);
+ASYN_API long  devGpib_writeMbboDirect(struct mbboDirectRecord * pmbboDirect);
+ASYN_API long  devGpib_initSi(struct stringinRecord * psi);
+ASYN_API long  devGpib_readSi(struct stringinRecord * psi);
+ASYN_API long  devGpib_initSo(struct stringoutRecord * pso);
+ASYN_API long  devGpib_writeSo(struct stringoutRecord * pso);
+ASYN_API long  devGpib_initWf(struct waveformRecord * pwf);
+ASYN_API long  devGpib_readWf(struct waveformRecord * pwf);
 
 /*
  * SRQ support

--- a/asyn/devGpib/devSupportGpib.c
+++ b/asyn/devGpib/devSupportGpib.c
@@ -35,7 +35,6 @@
 #include <epicsTime.h>
 #include <cantProceed.h>
 #include <epicsStdio.h>
-#include <shareLib.h>
 #include <iocsh.h>
 
 #include <epicsExport.h>
@@ -145,7 +144,7 @@ static devSupportGpib gpibSupport = {
     restoreEos,
     completeProcess
 };
-epicsShareDef devSupportGpib *pdevSupportGpib = &gpibSupport;
+devSupportGpib *pdevSupportGpib = &gpibSupport;
 
 /*Initialization routines*/
 static void commonGpibPvtInit(void);

--- a/asyn/devGpib/devSupportGpib.h
+++ b/asyn/devGpib/devSupportGpib.h
@@ -20,7 +20,6 @@
 #include <callback.h>
 #include <dbScan.h>
 #include <devSup.h>
-#include <shareLib.h>
 
 /* supported record types */
 #include <dbCommon.h>
@@ -176,7 +175,7 @@ struct devSupportGpib {
     int (*restoreEos)(gpibDpvt *pgpibDpvt,gpibCmd *pgpibCmd);
     void (*completeProcess)(gpibDpvt *pgpibDpvt);
 };
-epicsShareExtern devSupportGpib *pdevSupportGpib;
+ASYN_API extern devSupportGpib *pdevSupportGpib;
 
 /* macros for accessing some commonly used fields*/
 #define gpibDpvtGet(precord) ((gpibDpvt *)(precord)->dpvt)

--- a/asyn/drvAsynFTDI/drvAsynFTDIPort.cpp
+++ b/asyn/drvAsynFTDI/drvAsynFTDIPort.cpp
@@ -509,7 +509,7 @@ static const struct asynCommon drvAsynFTDIPortAsynCommon = {
 /*
  * Configure and register a USB port from a hostInfo string
  */
-epicsShareFunc int
+ASYN_API int
 drvAsynFTDIPortConfigure(const char *portName,
                          int vendor,
                          int product,

--- a/asyn/drvAsynFTDI/drvAsynFTDIPort.h
+++ b/asyn/drvAsynFTDI/drvAsynFTDIPort.h
@@ -4,15 +4,13 @@
 #ifndef DRVASYNFTDIPORT_H
 #define DRVASYNFTDIPORT_H
 
-#include <shareLib.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif  /* __cplusplus */
 
 #define UART_SPI_BIT    0x01 // 0 = UART; 1 = SPI
 
-epicsShareFunc int drvAsynFTDIPortConfigure(const char *portname,
+ASYN_API int drvAsynFTDIPortConfigure(const char *portname,
                                            const int vendor,
                                            const int product,
                                            const int baudrate,

--- a/asyn/drvAsynSerial/drvAsynIPPort.c
+++ b/asyn/drvAsynSerial/drvAsynIPPort.c
@@ -959,7 +959,7 @@ static const struct asynCommon drvAsynIPPortAsynCommon = {
 /*
  * Configure and register the drvAsynIPPort driver
 */
-epicsShareFunc int
+ASYN_API int
 drvAsynIPPortConfigure(const char *portName,
                        const char *hostInfo,
                        unsigned int priority,

--- a/asyn/drvAsynSerial/drvAsynIPPort.h
+++ b/asyn/drvAsynSerial/drvAsynIPPort.h
@@ -13,13 +13,13 @@
 #ifndef DRVASYNIPPORT_H
 #define DRVASYNIPPORT_H
 
-#include <shareLib.h>
+#include "asynAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif  /* __cplusplus */
 
-epicsShareFunc int drvAsynIPPortConfigure(const char *portName,
+ASYN_API int drvAsynIPPortConfigure(const char *portName,
                                           const char *hostInfo,
                                           unsigned int priority,
                                           int noAutoConnect,

--- a/asyn/drvAsynSerial/drvAsynIPServerPort.h
+++ b/asyn/drvAsynSerial/drvAsynIPServerPort.h
@@ -13,11 +13,13 @@
 #ifndef DRVASYNIPSERVERPORT_H
 #define DRVASYNIPSERVERPORT_H
 
+#include "asynAPI.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif  /* __cplusplus */
 
-int drvAsynIPServerPortConfigure(const char *portName, const char *serverInfo,
+ASYN_API int drvAsynIPServerPortConfigure(const char *portName, const char *serverInfo,
                                  unsigned int maxClients, unsigned int priority,
                                  int noAutoConnect, int noProcessEos);
 

--- a/asyn/drvAsynSerial/drvAsynSerialPort.c
+++ b/asyn/drvAsynSerial/drvAsynSerialPort.c
@@ -999,7 +999,7 @@ static const struct asynCommon asynCommonMethods = {
 /*
  * Configure and register a generic serial device
  */
-epicsShareFunc int
+ASYN_API int
 drvAsynSerialPortConfigure(char *portName,
                      char *ttyName,
                      unsigned int priority,

--- a/asyn/drvAsynSerial/drvAsynSerialPort.h
+++ b/asyn/drvAsynSerial/drvAsynSerialPort.h
@@ -13,7 +13,7 @@
 #ifndef DRVASYNLOCALSERIALPORT_H
 #define DRVASYNLOCALSERIALPORT_H
 
-#include <shareLib.h>
+#include "asynAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -23,7 +23,7 @@ extern "C" {
 #define ASYN_ERROR_PARITY  0x0001
 #define ASYN_ERROR_FRAMING 0x0002
 
-epicsShareFunc int drvAsynSerialPortConfigure(char *portName,
+ASYN_API int drvAsynSerialPortConfigure(char *portName,
                                               char *ttyName,
                                               unsigned int priority,
                                               int noAutoConnect,

--- a/asyn/drvAsynSerial/drvAsynSerialPortWin32.c
+++ b/asyn/drvAsynSerial/drvAsynSerialPortWin32.c
@@ -666,7 +666,7 @@ static const struct asynCommon asynCommonMethods = {
 /*
  * Configure and register a generic serial device
  */
-epicsShareFunc int
+ASYN_API int
 drvAsynSerialPortConfigure(char *portName,
                      char *ttyName,
                      unsigned int priority,

--- a/asyn/interfaces/asynCommonSyncIO.c
+++ b/asyn/interfaces/asynCommonSyncIO.c
@@ -20,8 +20,6 @@
 #include <cantProceed.h>
 #include <epicsEvent.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynDrvUser.h"
 #include "asynCommonSyncIO.h"
@@ -53,7 +51,7 @@ static asynCommonSyncIO interface = {
     disconnectDevice,
     report
 };
-epicsShareDef asynCommonSyncIO *pasynCommonSyncIO = &interface;
+asynCommonSyncIO *pasynCommonSyncIO = &interface;
 
 /* Private methods */
 static void connectDeviceCallback(asynUser *pasynUser);

--- a/asyn/interfaces/asynCommonSyncIO.h
+++ b/asyn/interfaces/asynCommonSyncIO.h
@@ -17,7 +17,6 @@
 #include <asynDriver.h>
 #include <epicsTypes.h>
 #include <stdio.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,7 +31,7 @@ typedef struct asynCommonSyncIO {
     asynStatus (*disconnectDevice)(asynUser *pasynUser);
     asynStatus (*report)(asynUser *pasynUser, FILE *fd, int details);
 } asynCommonSyncIO;
-epicsShareExtern asynCommonSyncIO *pasynCommonSyncIO;
+ASYN_API extern asynCommonSyncIO *pasynCommonSyncIO;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynDrvUser.h
+++ b/asyn/interfaces/asynDrvUser.h
@@ -17,7 +17,6 @@
 #define asynDrvUserH
 
 #include <epicsStdio.h>
-#include "shareLib.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/asyn/interfaces/asynEnum.h
+++ b/asyn/interfaces/asynEnum.h
@@ -17,7 +17,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,7 +49,7 @@ typedef struct asynEnumBase {
     asynStatus (*initialize)(const char *portName,
                             asynInterface *pEnumInterface);
 } asynEnumBase;
-epicsShareExtern asynEnumBase *pasynEnumBase;
+ASYN_API extern asynEnumBase *pasynEnumBase;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynEnumBase.c
+++ b/asyn/interfaces/asynEnumBase.c
@@ -14,15 +14,13 @@
 #include <epicsTypes.h>
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynEnum.h"
 
 static asynStatus initialize(const char *portName, asynInterface *pEnumInterface);
 
 static asynEnumBase enumBase = {initialize};
-epicsShareDef asynEnumBase *pasynEnumBase = &enumBase;
+asynEnumBase *pasynEnumBase = &enumBase;
 
 static asynStatus writeDefault(void *drvPvt, asynUser *pasynUser,
                               char *strings[], int values[], int severities[], size_t nElements);

--- a/asyn/interfaces/asynEnumSyncIO.c
+++ b/asyn/interfaces/asynEnumSyncIO.c
@@ -19,8 +19,6 @@
 
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynEnum.h"
 #include "asynDrvUser.h"
@@ -55,7 +53,7 @@ static asynEnumSyncIO interface = {
     writeOpOnce,
     readOpOnce,
 };
-epicsShareDef asynEnumSyncIO *pasynEnumSyncIO = &interface;
+asynEnumSyncIO *pasynEnumSyncIO = &interface;
 
 static asynStatus connect(const char *port, int addr,
    asynUser **ppasynUser, const char *drvInfo)

--- a/asyn/interfaces/asynEnumSyncIO.h
+++ b/asyn/interfaces/asynEnumSyncIO.h
@@ -16,7 +16,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,7 +35,7 @@ typedef struct asynEnumSyncIO {
     asynStatus (*readOnce)(const char *port, int addr, char *strings[], int values[],  int severities[],
                            size_t nElements, size_t *nIn, double timeout, const char *drvInfo);
 } asynEnumSyncIO;
-epicsShareExtern asynEnumSyncIO *pasynEnumSyncIO;
+ASYN_API extern asynEnumSyncIO *pasynEnumSyncIO;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynFloat32Array.h
+++ b/asyn/interfaces/asynFloat32Array.h
@@ -16,7 +16,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -57,7 +56,7 @@ typedef struct asynFloat32ArrayBase {
     asynStatus (*initialize)(const char *portName,
                             asynInterface *pfloat32ArrayInterface);
 } asynFloat32ArrayBase;
-epicsShareExtern asynFloat32ArrayBase *pasynFloat32ArrayBase;
+ASYN_API extern asynFloat32ArrayBase *pasynFloat32ArrayBase;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynFloat32ArrayBase.c
+++ b/asyn/interfaces/asynFloat32ArrayBase.c
@@ -15,8 +15,6 @@
 #include <epicsTypes.h>
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynFloat32Array.h"
 

--- a/asyn/interfaces/asynFloat32ArraySyncIO.c
+++ b/asyn/interfaces/asynFloat32ArraySyncIO.c
@@ -19,8 +19,6 @@
 
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynFloat32Array.h"
 #include "asynDrvUser.h"
@@ -53,7 +51,7 @@ static asynFloat32ArraySyncIO interface = {
     writeOpOnce,
     readOpOnce
 };
-epicsShareDef asynFloat32ArraySyncIO *pasynFloat32ArraySyncIO = &interface;
+asynFloat32ArraySyncIO *pasynFloat32ArraySyncIO = &interface;
 
 static asynStatus connect(const char *port, int addr,
    asynUser **ppasynUser, const char *drvInfo)

--- a/asyn/interfaces/asynFloat32ArraySyncIO.h
+++ b/asyn/interfaces/asynFloat32ArraySyncIO.h
@@ -16,7 +16,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,7 +33,7 @@ typedef struct asynFloat32ArraySyncIO {
     asynStatus (*readOnce)(const char *port, int addr,
                        epicsFloat32 *pvalue,size_t nelem,size_t *nIn,double timeout,const char *drvInfo);
 } asynFloat32ArraySyncIO;
-epicsShareExtern asynFloat32ArraySyncIO *pasynFloat32ArraySyncIO;
+ASYN_API extern asynFloat32ArraySyncIO *pasynFloat32ArraySyncIO;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynFloat64.h
+++ b/asyn/interfaces/asynFloat64.h
@@ -16,7 +16,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -53,7 +52,7 @@ typedef struct asynFloat64Base {
     asynStatus (*initialize)(const char *portName,
                             asynInterface *pasynFloat64Interface);
 } asynFloat64Base;
-epicsShareExtern asynFloat64Base *pasynFloat64Base;
+ASYN_API extern asynFloat64Base *pasynFloat64Base;
 
 
 #ifdef __cplusplus

--- a/asyn/interfaces/asynFloat64Array.h
+++ b/asyn/interfaces/asynFloat64Array.h
@@ -16,7 +16,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -57,7 +56,7 @@ typedef struct asynFloat64ArrayBase {
     asynStatus (*initialize)(const char *portName,
                             asynInterface *pfloat64ArrayInterface);
 } asynFloat64ArrayBase;
-epicsShareExtern asynFloat64ArrayBase *pasynFloat64ArrayBase;
+ASYN_API extern asynFloat64ArrayBase *pasynFloat64ArrayBase;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynFloat64ArrayBase.c
+++ b/asyn/interfaces/asynFloat64ArrayBase.c
@@ -15,8 +15,6 @@
 #include <epicsTypes.h>
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynFloat64Array.h"
 

--- a/asyn/interfaces/asynFloat64ArraySyncIO.c
+++ b/asyn/interfaces/asynFloat64ArraySyncIO.c
@@ -19,8 +19,6 @@
 
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynFloat64Array.h"
 #include "asynDrvUser.h"
@@ -53,7 +51,7 @@ static asynFloat64ArraySyncIO interface = {
     writeOpOnce,
     readOpOnce
 };
-epicsShareDef asynFloat64ArraySyncIO *pasynFloat64ArraySyncIO = &interface;
+asynFloat64ArraySyncIO *pasynFloat64ArraySyncIO = &interface;
 
 static asynStatus connect(const char *port, int addr,
    asynUser **ppasynUser, const char *drvInfo)

--- a/asyn/interfaces/asynFloat64ArraySyncIO.h
+++ b/asyn/interfaces/asynFloat64ArraySyncIO.h
@@ -16,7 +16,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,7 +33,7 @@ typedef struct asynFloat64ArraySyncIO {
     asynStatus (*readOnce)(const char *port, int addr,
                        epicsFloat64 *pvalue,size_t nelem,size_t *nIn,double timeout,const char *drvInfo);
 } asynFloat64ArraySyncIO;
-epicsShareExtern asynFloat64ArraySyncIO *pasynFloat64ArraySyncIO;
+ASYN_API extern asynFloat64ArraySyncIO *pasynFloat64ArraySyncIO;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynFloat64Base.c
+++ b/asyn/interfaces/asynFloat64Base.c
@@ -15,15 +15,13 @@
 #include <epicsStdio.h>
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynFloat64.h"
 
 static asynStatus initialize(const char *portName, asynInterface *pfloat64Interface);
 
 static asynFloat64Base float64Base = {initialize};
-epicsShareDef asynFloat64Base *pasynFloat64Base = &float64Base;
+asynFloat64Base *pasynFloat64Base = &float64Base;
 
 static asynStatus writeDefault(void *drvPvt, asynUser *pasynUser,
                                epicsFloat64 value);

--- a/asyn/interfaces/asynFloat64SyncIO.c
+++ b/asyn/interfaces/asynFloat64SyncIO.c
@@ -19,8 +19,6 @@
 
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynFloat64.h"
 #include "asynDrvUser.h"
@@ -53,7 +51,7 @@ static asynFloat64SyncIO interface = {
     writeOpOnce,
     readOpOnce
 };
-epicsShareDef asynFloat64SyncIO *pasynFloat64SyncIO = &interface;
+asynFloat64SyncIO *pasynFloat64SyncIO = &interface;
 
 static asynStatus connect(const char *port, int addr,
    asynUser **ppasynUser, const char *drvInfo)

--- a/asyn/interfaces/asynFloat64SyncIO.h
+++ b/asyn/interfaces/asynFloat64SyncIO.h
@@ -16,7 +16,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,7 +33,7 @@ typedef struct asynFloat64SyncIO {
     asynStatus (*readOnce)(const char *port, int addr,
                        epicsFloat64 *pvalue,double timeout,const char *drvInfo);
 } asynFloat64SyncIO;
-epicsShareExtern asynFloat64SyncIO *pasynFloat64SyncIO;
+ASYN_API extern asynFloat64SyncIO *pasynFloat64SyncIO;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynGenericPointer.h
+++ b/asyn/interfaces/asynGenericPointer.h
@@ -17,7 +17,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -57,7 +56,7 @@ typedef struct asynGenericPointerBase {
                             asynInterface *pasynGenericPointerInterface);
 } asynGenericPointerBase;
 
-epicsShareExtern asynGenericPointerBase *pasynGenericPointerBase;
+ASYN_API extern asynGenericPointerBase *pasynGenericPointerBase;
 
 
 #ifdef __cplusplus

--- a/asyn/interfaces/asynGenericPointerBase.c
+++ b/asyn/interfaces/asynGenericPointerBase.c
@@ -16,8 +16,6 @@
 #include <epicsStdio.h>
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include <asynDriver.h>
 
 #include "asynGenericPointer.h"
@@ -25,7 +23,7 @@
 static asynStatus initialize(const char *portName, asynInterface *pGenericPointerInterface);
 
 static asynGenericPointerBase GenericPointerBase = {initialize};
-epicsShareDef asynGenericPointerBase *pasynGenericPointerBase = &GenericPointerBase;
+asynGenericPointerBase *pasynGenericPointerBase = &GenericPointerBase;
 
 static asynStatus writeDefault(void *drvPvt, asynUser *pasynUser, void *pointer);
 static asynStatus readDefault(void *drvPvt, asynUser *pasynUser, void *pointer);

--- a/asyn/interfaces/asynGenericPointerSyncIO.c
+++ b/asyn/interfaces/asynGenericPointerSyncIO.c
@@ -19,8 +19,6 @@
 
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynGenericPointer.h"
 #include "asynDrvUser.h"
@@ -59,7 +57,7 @@ static asynGenericPointerSyncIO interface = {
     readOpOnce,
     writeReadOpOnce
 };
-epicsShareDef asynGenericPointerSyncIO *pasynGenericPointerSyncIO = &interface;
+asynGenericPointerSyncIO *pasynGenericPointerSyncIO = &interface;
 
 static asynStatus connect(const char *port, int addr,
    asynUser **ppasynUser, const char *drvInfo)

--- a/asyn/interfaces/asynGenericPointerSyncIO.h
+++ b/asyn/interfaces/asynGenericPointerSyncIO.h
@@ -16,7 +16,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,7 +36,7 @@ typedef struct asynGenericPointerSyncIO {
     asynStatus (*writeReadOnce)(const char *port, int addr,
                        void *pwrite_buffer,void *pread_buffer,double timeout,const char *drvInfo);
 } asynGenericPointerSyncIO;
-epicsShareExtern asynGenericPointerSyncIO *pasynGenericPointerSyncIO;
+ASYN_API extern asynGenericPointerSyncIO *pasynGenericPointerSyncIO;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynInt16Array.h
+++ b/asyn/interfaces/asynInt16Array.h
@@ -17,7 +17,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,7 +49,7 @@ typedef struct asynInt16ArrayBase {
     asynStatus (*initialize)(const char *portName,
                             asynInterface *pint16ArrayInterface);
 } asynInt16ArrayBase;
-epicsShareExtern asynInt16ArrayBase *pasynInt16ArrayBase;
+ASYN_API extern asynInt16ArrayBase *pasynInt16ArrayBase;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynInt16ArrayBase.c
+++ b/asyn/interfaces/asynInt16ArrayBase.c
@@ -15,8 +15,6 @@
 #include <epicsTypes.h>
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynInt16Array.h"
 

--- a/asyn/interfaces/asynInt16ArraySyncIO.c
+++ b/asyn/interfaces/asynInt16ArraySyncIO.c
@@ -19,8 +19,6 @@
 
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynInt16Array.h"
 #include "asynDrvUser.h"
@@ -53,7 +51,7 @@ static asynInt16ArraySyncIO interface = {
     writeOpOnce,
     readOpOnce
 };
-epicsShareDef asynInt16ArraySyncIO *pasynInt16ArraySyncIO = &interface;
+asynInt16ArraySyncIO *pasynInt16ArraySyncIO = &interface;
 
 static asynStatus connect(const char *port, int addr,
    asynUser **ppasynUser, const char *drvInfo)

--- a/asyn/interfaces/asynInt16ArraySyncIO.h
+++ b/asyn/interfaces/asynInt16ArraySyncIO.h
@@ -16,7 +16,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,7 +33,7 @@ typedef struct asynInt16ArraySyncIO {
     asynStatus (*readOnce)(const char *port, int addr,
                        epicsInt16 *pvalue,size_t nelem,size_t *nIn,double timeout,const char *drvInfo);
 } asynInt16ArraySyncIO;
-epicsShareExtern asynInt16ArraySyncIO *pasynInt16ArraySyncIO;
+ASYN_API extern asynInt16ArraySyncIO *pasynInt16ArraySyncIO;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynInt32.h
+++ b/asyn/interfaces/asynInt32.h
@@ -16,7 +16,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,7 +55,7 @@ typedef struct asynInt32Base {
     asynStatus (*initialize)(const char *portName,
                             asynInterface *pint32Interface);
 } asynInt32Base;
-epicsShareExtern asynInt32Base *pasynInt32Base;
+ASYN_API extern asynInt32Base *pasynInt32Base;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynInt32Array.h
+++ b/asyn/interfaces/asynInt32Array.h
@@ -17,7 +17,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,7 +49,7 @@ typedef struct asynInt32ArrayBase {
     asynStatus (*initialize)(const char *portName,
                             asynInterface *pint32ArrayInterface);
 } asynInt32ArrayBase;
-epicsShareExtern asynInt32ArrayBase *pasynInt32ArrayBase;
+ASYN_API extern asynInt32ArrayBase *pasynInt32ArrayBase;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynInt32ArrayBase.c
+++ b/asyn/interfaces/asynInt32ArrayBase.c
@@ -15,8 +15,6 @@
 #include <epicsTypes.h>
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynInt32Array.h"
 

--- a/asyn/interfaces/asynInt32ArraySyncIO.c
+++ b/asyn/interfaces/asynInt32ArraySyncIO.c
@@ -19,8 +19,6 @@
 
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynInt32Array.h"
 #include "asynDrvUser.h"
@@ -53,7 +51,7 @@ static asynInt32ArraySyncIO interface = {
     writeOpOnce,
     readOpOnce
 };
-epicsShareDef asynInt32ArraySyncIO *pasynInt32ArraySyncIO = &interface;
+asynInt32ArraySyncIO *pasynInt32ArraySyncIO = &interface;
 
 static asynStatus connect(const char *port, int addr,
    asynUser **ppasynUser, const char *drvInfo)

--- a/asyn/interfaces/asynInt32ArraySyncIO.h
+++ b/asyn/interfaces/asynInt32ArraySyncIO.h
@@ -16,7 +16,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,7 +33,7 @@ typedef struct asynInt32ArraySyncIO {
     asynStatus (*readOnce)(const char *port, int addr,
                        epicsInt32 *pvalue,size_t nelem,size_t *nIn,double timeout,const char *drvInfo);
 } asynInt32ArraySyncIO;
-epicsShareExtern asynInt32ArraySyncIO *pasynInt32ArraySyncIO;
+ASYN_API extern asynInt32ArraySyncIO *pasynInt32ArraySyncIO;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynInt32Base.c
+++ b/asyn/interfaces/asynInt32Base.c
@@ -14,15 +14,13 @@
 #include <epicsTypes.h>
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynInt32.h"
 
 static asynStatus initialize(const char *portName, asynInterface *pint32Interface);
 
 static asynInt32Base int32Base = {initialize};
-epicsShareDef asynInt32Base *pasynInt32Base = &int32Base;
+asynInt32Base *pasynInt32Base = &int32Base;
 
 static asynStatus writeDefault(void *drvPvt, asynUser *pasynUser,
                               epicsInt32 value);

--- a/asyn/interfaces/asynInt32SyncIO.c
+++ b/asyn/interfaces/asynInt32SyncIO.c
@@ -19,8 +19,6 @@
 
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynInt32.h"
 #include "asynDrvUser.h"
@@ -59,7 +57,7 @@ static asynInt32SyncIO interface = {
     readOpOnce,
     getBoundsOnce
 };
-epicsShareDef asynInt32SyncIO *pasynInt32SyncIO = &interface;
+asynInt32SyncIO *pasynInt32SyncIO = &interface;
 
 static asynStatus connect(const char *port, int addr,
    asynUser **ppasynUser, const char *drvInfo)

--- a/asyn/interfaces/asynInt32SyncIO.h
+++ b/asyn/interfaces/asynInt32SyncIO.h
@@ -16,7 +16,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -38,7 +37,7 @@ typedef struct asynInt32SyncIO {
     asynStatus (*getBoundsOnce)(const char *port, int addr,
                     epicsInt32 *plow, epicsInt32 *phigh,const char *drvInfo);
 } asynInt32SyncIO;
-epicsShareExtern asynInt32SyncIO *pasynInt32SyncIO;
+ASYN_API extern asynInt32SyncIO *pasynInt32SyncIO;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynInt64.h
+++ b/asyn/interfaces/asynInt64.h
@@ -16,7 +16,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,7 +55,7 @@ typedef struct asynInt64Base {
     asynStatus (*initialize)(const char *portName,
                             asynInterface *pint64Interface);
 } asynInt64Base;
-epicsShareExtern asynInt64Base *pasynInt64Base;
+ASYN_API extern asynInt64Base *pasynInt64Base;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynInt64Array.h
+++ b/asyn/interfaces/asynInt64Array.h
@@ -17,7 +17,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,7 +49,7 @@ typedef struct asynInt64ArrayBase {
     asynStatus (*initialize)(const char *portName,
                             asynInterface *pint64ArrayInterface);
 } asynInt64ArrayBase;
-epicsShareExtern asynInt64ArrayBase *pasynInt64ArrayBase;
+ASYN_API extern asynInt64ArrayBase *pasynInt64ArrayBase;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynInt64ArrayBase.c
+++ b/asyn/interfaces/asynInt64ArrayBase.c
@@ -15,8 +15,6 @@
 #include <epicsTypes.h>
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynInt64Array.h"
 

--- a/asyn/interfaces/asynInt64ArraySyncIO.c
+++ b/asyn/interfaces/asynInt64ArraySyncIO.c
@@ -19,8 +19,6 @@
 
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynInt64Array.h"
 #include "asynDrvUser.h"
@@ -53,7 +51,7 @@ static asynInt64ArraySyncIO interface = {
     writeOpOnce,
     readOpOnce
 };
-epicsShareDef asynInt64ArraySyncIO *pasynInt64ArraySyncIO = &interface;
+asynInt64ArraySyncIO *pasynInt64ArraySyncIO = &interface;
 
 static asynStatus connect(const char *port, int addr,
    asynUser **ppasynUser, const char *drvInfo)

--- a/asyn/interfaces/asynInt64ArraySyncIO.h
+++ b/asyn/interfaces/asynInt64ArraySyncIO.h
@@ -16,7 +16,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,7 +33,7 @@ typedef struct asynInt64ArraySyncIO {
     asynStatus (*readOnce)(const char *port, int addr,
                        epicsInt64 *pvalue,size_t nelem,size_t *nIn,double timeout,const char *drvInfo);
 } asynInt64ArraySyncIO;
-epicsShareExtern asynInt64ArraySyncIO *pasynInt64ArraySyncIO;
+ASYN_API extern asynInt64ArraySyncIO *pasynInt64ArraySyncIO;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynInt64Base.c
+++ b/asyn/interfaces/asynInt64Base.c
@@ -14,15 +14,13 @@
 #include <epicsTypes.h>
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynInt64.h"
 
 static asynStatus initialize(const char *portName, asynInterface *pint64Interface);
 
 static asynInt64Base int64Base = {initialize};
-epicsShareDef asynInt64Base *pasynInt64Base = &int64Base;
+asynInt64Base *pasynInt64Base = &int64Base;
 
 static asynStatus writeDefault(void *drvPvt, asynUser *pasynUser,
                               epicsInt64 value);

--- a/asyn/interfaces/asynInt64SyncIO.c
+++ b/asyn/interfaces/asynInt64SyncIO.c
@@ -19,8 +19,6 @@
 
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynInt64.h"
 #include "asynDrvUser.h"
@@ -59,7 +57,7 @@ static asynInt64SyncIO interface = {
     readOpOnce,
     getBoundsOnce
 };
-epicsShareDef asynInt64SyncIO *pasynInt64SyncIO = &interface;
+asynInt64SyncIO *pasynInt64SyncIO = &interface;
 
 static asynStatus connect(const char *port, int addr,
    asynUser **ppasynUser, const char *drvInfo)

--- a/asyn/interfaces/asynInt64SyncIO.h
+++ b/asyn/interfaces/asynInt64SyncIO.h
@@ -16,7 +16,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -38,7 +37,7 @@ typedef struct asynInt64SyncIO {
     asynStatus (*getBoundsOnce)(const char *port, int addr,
                     epicsInt64 *plow, epicsInt64 *phigh,const char *drvInfo);
 } asynInt64SyncIO;
-epicsShareExtern asynInt64SyncIO *pasynInt64SyncIO;
+ASYN_API extern asynInt64SyncIO *pasynInt64SyncIO;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynInt8Array.h
+++ b/asyn/interfaces/asynInt8Array.h
@@ -17,7 +17,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,7 +49,7 @@ typedef struct asynInt8ArrayBase {
     asynStatus (*initialize)(const char *portName,
                             asynInterface *pint8ArrayInterface);
 } asynInt8ArrayBase;
-epicsShareExtern asynInt8ArrayBase *pasynInt8ArrayBase;
+ASYN_API extern asynInt8ArrayBase *pasynInt8ArrayBase;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynInt8ArrayBase.c
+++ b/asyn/interfaces/asynInt8ArrayBase.c
@@ -15,8 +15,6 @@
 #include <epicsTypes.h>
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynInt8Array.h"
 

--- a/asyn/interfaces/asynInt8ArraySyncIO.c
+++ b/asyn/interfaces/asynInt8ArraySyncIO.c
@@ -19,8 +19,6 @@
 
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynInt8Array.h"
 #include "asynDrvUser.h"
@@ -53,7 +51,7 @@ static asynInt8ArraySyncIO interface = {
     writeOpOnce,
     readOpOnce
 };
-epicsShareDef asynInt8ArraySyncIO *pasynInt8ArraySyncIO = &interface;
+asynInt8ArraySyncIO *pasynInt8ArraySyncIO = &interface;
 
 static asynStatus connect(const char *port, int addr,
    asynUser **ppasynUser, const char *drvInfo)

--- a/asyn/interfaces/asynInt8ArraySyncIO.h
+++ b/asyn/interfaces/asynInt8ArraySyncIO.h
@@ -16,7 +16,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,7 +33,7 @@ typedef struct asynInt8ArraySyncIO {
     asynStatus (*readOnce)(const char *port, int addr,
                        epicsInt8 *pvalue,size_t nelem,size_t *nIn,double timeout,const char *drvInfo);
 } asynInt8ArraySyncIO;
-epicsShareExtern asynInt8ArraySyncIO *pasynInt8ArraySyncIO;
+ASYN_API extern asynInt8ArraySyncIO *pasynInt8ArraySyncIO;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynOctet.h
+++ b/asyn/interfaces/asynOctet.h
@@ -11,7 +11,6 @@
 
 #ifndef asynOctetH
 #define asynOctetH
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -71,7 +70,7 @@ typedef struct asynOctetBase {
     void       (*callInterruptUsers)(asynUser *pasynUser,void *pasynPvt,
         char *data,size_t *nbytesTransfered,int *eomReason);
 } asynOctetBase;
-epicsShareExtern asynOctetBase *pasynOctetBase;
+ASYN_API extern asynOctetBase *pasynOctetBase;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynOctetBase.c
+++ b/asyn/interfaces/asynOctetBase.c
@@ -21,8 +21,6 @@
 #include <epicsString.h>
 #include <epicsTypes.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynInterposeEos.h"
 #include "asynOctet.h"
@@ -52,7 +50,7 @@ static void callInterruptUsers(asynUser *pasynUser,void *pasynPvt,
     char *data,size_t *nbytesTransfered,int *eomReason);
 
 static asynOctetBase octetBase = {initialize,callInterruptUsers};
-epicsShareDef asynOctetBase *pasynOctetBase = &octetBase;
+asynOctetBase *pasynOctetBase = &octetBase;
 
 static asynStatus writeIt(void *drvPvt, asynUser *pasynUser,
     const char *data,size_t numchars,size_t *nbytesTransfered);

--- a/asyn/interfaces/asynOctetSyncIO.c
+++ b/asyn/interfaces/asynOctetSyncIO.c
@@ -25,8 +25,6 @@
 
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynOctet.h"
 #include "asynDrvUser.h"
@@ -106,7 +104,7 @@ static asynOctetSyncIO asynOctetSyncIOManager = {
     setOutputEosOnce,
     getOutputEosOnce
 };
-epicsShareDef asynOctetSyncIO *pasynOctetSyncIO = &asynOctetSyncIOManager;
+asynOctetSyncIO *pasynOctetSyncIO = &asynOctetSyncIOManager;
 
 static asynStatus connect(const char *port, int addr,
            asynUser **ppasynUser,const char *drvInfo)

--- a/asyn/interfaces/asynOctetSyncIO.h
+++ b/asyn/interfaces/asynOctetSyncIO.h
@@ -19,7 +19,6 @@
 #ifndef INCasynOctetSyncIOh
 #define INCasynOctetSyncIOh 1
 
-#include <shareLib.h>
 #include "asynDriver.h"
 
 #ifdef __cplusplus
@@ -70,7 +69,7 @@ typedef struct asynOctetSyncIO {
    asynStatus (*getOutputEosOnce)(const char *port, int addr,
                   char *eos, int eossize, int *eoslen,const char *drvInfo);
 } asynOctetSyncIO;
-epicsShareExtern asynOctetSyncIO *pasynOctetSyncIO;
+ASYN_API extern asynOctetSyncIO *pasynOctetSyncIO;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynOption.h
+++ b/asyn/interfaces/asynOption.h
@@ -10,7 +10,6 @@
 
 #ifndef asynOptionH
 #define asynOptionH
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/asyn/interfaces/asynOptionSyncIO.c
+++ b/asyn/interfaces/asynOptionSyncIO.c
@@ -19,8 +19,6 @@
 
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynOption.h"
 #include "asynDrvUser.h"
@@ -53,7 +51,7 @@ static asynOptionSyncIO interface = {
     setOptionOnce,
     getOptionOnce,
 };
-epicsShareDef asynOptionSyncIO *pasynOptionSyncIO = &interface;
+asynOptionSyncIO *pasynOptionSyncIO = &interface;
 
 static asynStatus connect(const char *port, int addr,
    asynUser **ppasynUser, const char *drvInfo)

--- a/asyn/interfaces/asynOptionSyncIO.h
+++ b/asyn/interfaces/asynOptionSyncIO.h
@@ -16,7 +16,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,7 +33,7 @@ typedef struct asynOptionSyncIO {
     asynStatus (*getOptionOnce)(const char *port, int addr,
                     const char *key, char *val, int sizeval, double timeout, const char *drvInfo);
 } asynOptionSyncIO;
-epicsShareExtern asynOptionSyncIO *pasynOptionSyncIO;
+ASYN_API extern asynOptionSyncIO *pasynOptionSyncIO;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynStandardInterfaces.h
+++ b/asyn/interfaces/asynStandardInterfaces.h
@@ -107,7 +107,7 @@ typedef struct asynStandardInterfacesBase {
                              asynUser *pasynUser, void *pPvt);
 } asynStandardInterfacesBase;
 
-epicsShareExtern asynStandardInterfacesBase *pasynStandardInterfacesBase;
+ASYN_API extern asynStandardInterfacesBase *pasynStandardInterfacesBase;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynStandardInterfacesBase.c
+++ b/asyn/interfaces/asynStandardInterfacesBase.c
@@ -17,8 +17,6 @@
 #include <epicsTypes.h>
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynStandardInterfaces.h"
 
@@ -329,5 +327,5 @@ static asynStatus initialize(const char *portName, asynStandardInterfaces *pInte
 
 
 static asynStandardInterfacesBase standardInterfacesBase = {initialize};
-epicsShareDef asynStandardInterfacesBase *pasynStandardInterfacesBase = &standardInterfacesBase;
+asynStandardInterfacesBase *pasynStandardInterfacesBase = &standardInterfacesBase;
 

--- a/asyn/interfaces/asynUInt32Digital.h
+++ b/asyn/interfaces/asynUInt32Digital.h
@@ -17,7 +17,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -68,7 +67,7 @@ typedef struct asynUInt32DigitalBase {
     asynStatus (*initialize)(const char *portName,
                             asynInterface *pasynUInt32DigitalInterface);
 } asynUInt32DigitalBase;
-epicsShareExtern asynUInt32DigitalBase *pasynUInt32DigitalBase;
+ASYN_API extern asynUInt32DigitalBase *pasynUInt32DigitalBase;
 
 
 #ifdef __cplusplus

--- a/asyn/interfaces/asynUInt32DigitalBase.c
+++ b/asyn/interfaces/asynUInt32DigitalBase.c
@@ -14,14 +14,12 @@
 #include <epicsTypes.h>
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynUInt32Digital.h"
 
 static asynStatus initialize(const char *portName, asynInterface *pasynUInt32DigitalInterface);
 static asynUInt32DigitalBase uint32Base = {initialize};
-epicsShareDef asynUInt32DigitalBase *pasynUInt32DigitalBase = &uint32Base;
+asynUInt32DigitalBase *pasynUInt32DigitalBase = &uint32Base;
 
 static asynStatus writeDefault(void *drvPvt, asynUser *pasynUser,
                                epicsUInt32 value, epicsUInt32 mask);

--- a/asyn/interfaces/asynUInt32DigitalSyncIO.c
+++ b/asyn/interfaces/asynUInt32DigitalSyncIO.c
@@ -19,8 +19,6 @@
 
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynUInt32Digital.h"
 #include "asynDrvUser.h"
@@ -77,7 +75,7 @@ static asynUInt32DigitalSyncIO interface = {
     clearInterruptOnce,
     getInterruptOnce
 };
-epicsShareDef asynUInt32DigitalSyncIO *pasynUInt32DigitalSyncIO = &interface;
+asynUInt32DigitalSyncIO *pasynUInt32DigitalSyncIO = &interface;
 
 static asynStatus connect(const char *port, int addr,
    asynUser **ppasynUser, const char *drvInfo)

--- a/asyn/interfaces/asynUInt32DigitalSyncIO.h
+++ b/asyn/interfaces/asynUInt32DigitalSyncIO.h
@@ -16,7 +16,6 @@
 
 #include <asynDriver.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -52,7 +51,7 @@ typedef struct asynUInt32DigitalSyncIO {
                        epicsUInt32 *mask, interruptReason reason,double timeout,
                        const char *drvInfo);
 } asynUInt32DigitalSyncIO;
-epicsShareExtern asynUInt32DigitalSyncIO *pasynUInt32DigitalSyncIO;
+ASYN_API extern asynUInt32DigitalSyncIO *pasynUInt32DigitalSyncIO;
 
 #ifdef __cplusplus
 }

--- a/asyn/interfaces/asynXXXArrayBase.h
+++ b/asyn/interfaces/asynXXXArrayBase.h
@@ -17,7 +17,7 @@
 static asynStatus initialize(const char *portName, asynInterface *pInterface); \
  \
 static INTERFACE_BASE arrayBase = {initialize}; \
-epicsShareDef INTERFACE_BASE *PINTERFACE_BASE = &arrayBase; \
+INTERFACE_BASE *PINTERFACE_BASE = &arrayBase; \
  \
 static asynStatus writeDefault(void *drvPvt, asynUser *pasynUser, \
                                EPICS_TYPE *value, size_t nelem); \

--- a/asyn/interfaces/asynXXXArraySyncIO.c
+++ b/asyn/interfaces/asynXXXArraySyncIO.c
@@ -19,8 +19,6 @@
 
 #include <cantProceed.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynFloat64.h"
 #include "asynDrvUser.h"
@@ -54,7 +52,7 @@ static asynFloat64SyncIO interface = {
     writeOpOnce,
     readOpOnce
 };
-epicsShareDef asynFloat64SyncIO *pasynFloat64SyncIO = &interface;
+asynFloat64SyncIO *pasynFloat64SyncIO = &interface;
 
 static asynStatus connect(const char *port, int addr,
    asynUser **ppasynUser, const char *drvInfo)

--- a/asyn/miscellaneous/asynInterposeCom.c
+++ b/asyn/miscellaneous/asynInterposeCom.c
@@ -20,8 +20,6 @@
 #include <epicsString.h>
 #include <epicsTypes.h>
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynOctet.h"
 #include "asynOption.h"
@@ -726,7 +724,7 @@ exceptionHandler(asynUser *pasynUser, asynException exception)
     }
 }
 
-epicsShareFunc int
+ASYN_API int
 asynInterposeCOM(const char *portName)
 {
     interposePvt *pinterposePvt;

--- a/asyn/miscellaneous/asynInterposeCom.h
+++ b/asyn/miscellaneous/asynInterposeCom.h
@@ -8,13 +8,11 @@
 #ifndef asynInterposeCom_H
 #define asynInterposeCom_H
 
-#include <shareLib.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif  /* __cplusplus */
 
-epicsShareFunc int asynInterposeCOM(const char *portName);
+ASYN_API int asynInterposeCOM(const char *portName);
 
 #ifdef __cplusplus
 }

--- a/asyn/miscellaneous/asynInterposeDelay.c
+++ b/asyn/miscellaneous/asynInterposeDelay.c
@@ -172,7 +172,7 @@ static asynOption option = {
 };
 
 
-epicsShareFunc int
+ASYN_API int
 asynInterposeDelay(const char *portName, int addr, double delay)
 {
     interposePvt *pvt;

--- a/asyn/miscellaneous/asynInterposeEcho.c
+++ b/asyn/miscellaneous/asynInterposeEcho.c
@@ -162,7 +162,7 @@ static asynOctet octet = {
 };
 
 /* asynOctet methods */
-epicsShareFunc int
+ASYN_API int
 asynInterposeEcho(const char *portName, int addr)
 {
     interposePvt *pvt;

--- a/asyn/miscellaneous/asynInterposeEos.c
+++ b/asyn/miscellaneous/asynInterposeEos.c
@@ -81,7 +81,7 @@ static asynOctet octet = {
     setInputEos,getInputEos,setOutputEos,getOutputEos
 };
 
-epicsShareFunc int asynInterposeEosConfig(const char *portName,int addr,
+ASYN_API int asynInterposeEosConfig(const char *portName,int addr,
     int processEosIn,int processEosOut)
 {
     eosPvt        *peosPvt;

--- a/asyn/miscellaneous/asynInterposeEos.h
+++ b/asyn/miscellaneous/asynInterposeEos.h
@@ -17,13 +17,11 @@
 #ifndef asynInterposeEos_H
 #define asynInterposeEos_H
 
-#include <shareLib.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif  /* __cplusplus */
 
-epicsShareFunc int asynInterposeEosConfig(const char *portName,int addr,
+ASYN_API int asynInterposeEosConfig(const char *portName,int addr,
                                          int processEosIn,int processEosOut);
 
 #ifdef __cplusplus

--- a/asyn/miscellaneous/asynInterposeFlush.c
+++ b/asyn/miscellaneous/asynInterposeFlush.c
@@ -62,7 +62,7 @@ static asynOctet octet = {
     setInputEos,getInputEos,setOutputEos,getOutputEos
 };
 
-epicsShareFunc int
+ASYN_API int
 asynInterposeFlushConfig(const char *portName,int addr,int timeout)
 {
     interposePvt *pinterposePvt;

--- a/asyn/miscellaneous/asynInterposeFlush.h
+++ b/asyn/miscellaneous/asynInterposeFlush.h
@@ -11,13 +11,11 @@
 #ifndef asynInterposeEos_H
 #define asynInterposeEos_H
 
-#include <shareLib.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif  /* __cplusplus */
 
-epicsShareFunc int asynInterposeFlushConfig(
+ASYN_API int asynInterposeFlushConfig(
     const char *portName,int addr, int timeout);
 
 #ifdef __cplusplus

--- a/asyn/miscellaneous/asynShellCommands.c
+++ b/asyn/miscellaneous/asynShellCommands.c
@@ -29,8 +29,6 @@
   #include <windows.h>
 #endif
 
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "asynDriver.h"
 #include "asynOctet.h"
 #include "asynOption.h"
@@ -104,7 +102,7 @@ static void setOption(asynUser *pasynUser)
     epicsEventSignal(poptionargs->done);
 }
 
-epicsShareFunc int
+ASYN_API int
  asynSetOption(const char *portName, int addr, const char *key, const char *val)
 {
     asynUser *pasynUser;
@@ -152,7 +150,7 @@ static void showOption(asynUser *pasynUser)
     epicsEventSignal(poptionargs->done);
 }
 
-epicsShareFunc int
+ASYN_API int
  asynShowOption(const char *portName, int addr,const char *key)
 {
     asynInterface *pasynInterface;
@@ -329,7 +327,7 @@ static asynIOPvt* asynFindEntry(const char *name)
     return((asynIOPvt *)hashEntry->userPvt);
 }
 
-epicsShareFunc int
+ASYN_API int
     asynOctetConnect(const char *entry, const char *port, int addr,
              int timeout, int buffer_len, const char *drvInfo)
 {
@@ -362,7 +360,7 @@ epicsShareFunc int
     return(0);
 }
 
-epicsShareFunc int
+ASYN_API int
     asynOctetDisconnect(const char *entry)
 {
     asynIOPvt *pPvt;
@@ -395,7 +393,7 @@ epicsShareFunc int
     return(0);
 }
 
-epicsShareFunc int
+ASYN_API int
     asynOctetRead(const char *entry, int nread)
 {
     asynStatus status;
@@ -426,7 +424,7 @@ epicsShareFunc int
     return (int)ninp;
 }
 
-epicsShareFunc int
+ASYN_API int
     asynOctetWrite(const char *entry, const char *output)
 {
     asynStatus status;
@@ -459,7 +457,7 @@ epicsShareFunc int
     return (int)nout;
 }
 
-epicsShareFunc int
+ASYN_API int
     asynOctetWriteRead(const char *entry, const char *output, int nread)
 {
     asynStatus status;
@@ -501,7 +499,7 @@ epicsShareFunc int
     return (int)ninp;
 }
 
-epicsShareFunc int
+ASYN_API int
     asynOctetFlush(const char *entry)
 {
     asynIOPvt *pPvt;
@@ -524,31 +522,31 @@ epicsShareFunc int
     return(0);
 }
 
-epicsShareFunc int
+ASYN_API int
     asynOctetSetInputEos(const char *portName, int addr, const char *eosin)
 {
    return asynSetEos(portName, addr, eosIn, eosin) == asynSuccess ? 0 : -1;
 }
 
-epicsShareFunc int
+ASYN_API int
     asynOctetGetInputEos(const char *portName, int addr)
 {
    return asynShowEos(portName, addr, eosIn) == asynSuccess ? 0 : -1;
 }
 
-epicsShareFunc int
+ASYN_API int
     asynOctetSetOutputEos(const char *portName, int addr, const char *eosout)
 {
    return asynSetEos(portName, addr, eosOut, eosout)==asynSuccess ? 0 : -1;
 }
 
-epicsShareFunc int
+ASYN_API int
     asynOctetGetOutputEos(const char *portName, int addr)
 {
    return asynShowEos(portName, addr, eosOut) == asynSuccess ? 0 : -1;
 }
 
-epicsShareFunc int
+ASYN_API int
     asynWaitConnect(const char *portName, double timeout)
 {
     asynUser      *pasynUser=NULL;
@@ -585,7 +583,7 @@ static const iocshArg asynReportArg1 = {"port", iocshArgString};
 static const iocshArg *const asynReportArgs[] = {
     &asynReportArg0,&asynReportArg1};
 static const iocshFuncDef asynReportDef = {"asynReport", 2, asynReportArgs};
-epicsShareFunc int
+ASYN_API int
  asynReport(int level, const char *portName)
 {
     pasynManager->report(stdout,level,portName);
@@ -624,7 +622,7 @@ static const iocshArg *const asynSetTraceMaskArgs[] = {
     &asynSetTraceMaskArg0,&asynSetTraceMaskArg1,&asynSetTraceMaskArg2};
 static const iocshFuncDef asynSetTraceMaskDef =
     {"asynSetTraceMask", 3, asynSetTraceMaskArgs};
-epicsShareFunc int
+ASYN_API int
  asynSetTraceMask(const char *portName,int addr,int mask)
 {
     asynUser *pasynUser=NULL;
@@ -694,7 +692,7 @@ static const iocshArg *const asynSetTraceIOMaskArgs[] = {
     &asynSetTraceIOMaskArg0,&asynSetTraceIOMaskArg1,&asynSetTraceIOMaskArg2};
 static const iocshFuncDef asynSetTraceIOMaskDef =
     {"asynSetTraceIOMask", 3, asynSetTraceIOMaskArgs};
-epicsShareFunc int
+ASYN_API int
  asynSetTraceIOMask(const char *portName,int addr,int mask)
 {
     asynUser *pasynUser=NULL;
@@ -760,7 +758,7 @@ static const iocshArg *const asynSetTraceInfoMaskArgs[] = {
     &asynSetTraceInfoMaskArg0,&asynSetTraceInfoMaskArg1,&asynSetTraceInfoMaskArg2};
 static const iocshFuncDef asynSetTraceInfoMaskDef =
     {"asynSetTraceInfoMask", 3, asynSetTraceInfoMaskArgs};
-epicsShareFunc int
+ASYN_API int
  asynSetTraceInfoMask(const char *portName,int addr,int mask)
 {
     asynUser *pasynUser=NULL;
@@ -819,7 +817,7 @@ static void asynSetTraceInfoMaskCall(const iocshArgBuf * args) {
     asynSetTraceInfoMask(portName,addr,mask);
 }
 
-epicsShareFunc int
+ASYN_API int
  asynSetTraceFile(const char *portName,int addr,const char *filename)
 {
     asynUser        *pasynUser;
@@ -876,7 +874,7 @@ static const iocshArg *const asynSetTraceIOTruncateSizeArgs[] = {
     &asynSetTraceIOTruncateSizeArg0,&asynSetTraceIOTruncateSizeArg1,&asynSetTraceIOTruncateSizeArg2};
 static const iocshFuncDef asynSetTraceIOTruncateSizeDef =
     {"asynSetTraceIOTruncateSize", 3, asynSetTraceIOTruncateSizeArgs};
-epicsShareFunc int
+ASYN_API int
  asynSetTraceIOTruncateSize(const char *portName,int addr,int size)
 {
     asynUser *pasynUser;
@@ -910,7 +908,7 @@ static const iocshArg *const asynEnableArgs[] = {
     &asynEnableArg0,&asynEnableArg1,&asynEnableArg2};
 static const iocshFuncDef asynEnableDef =
     {"asynEnable", 3, asynEnableArgs};
-epicsShareFunc int
+ASYN_API int
  asynEnable(const char *portName,int addr,int yesNo)
 {
     asynUser *pasynUser;
@@ -944,7 +942,7 @@ static const iocshArg *const asynAutoConnectArgs[] = {
     &asynAutoConnectArg0,&asynAutoConnectArg1,&asynAutoConnectArg2};
 static const iocshFuncDef asynAutoConnectDef =
     {"asynAutoConnect", 3, asynAutoConnectArgs};
-epicsShareFunc int
+ASYN_API int
  asynAutoConnect(const char *portName,int addr,int yesNo)
 {
     asynUser *pasynUser;
@@ -1142,7 +1140,7 @@ static void asynUnregisterTimeStampSourceCall(const iocshArgBuf *args)
 {
     asynUnregisterTimeStampSource(args[0].sval);
 }
-epicsShareFunc int asynRegisterTimeStampSource(const char *portName, const char *functionName)
+ASYN_API int asynRegisterTimeStampSource(const char *portName, const char *functionName)
 {
     asynUser *pasynUser;
     asynStatus status;
@@ -1167,7 +1165,7 @@ epicsShareFunc int asynRegisterTimeStampSource(const char *portName, const char 
     return 0;
 }
 
-epicsShareFunc int asynUnregisterTimeStampSource(const char *portName)
+ASYN_API int asynUnregisterTimeStampSource(const char *portName)
 {
     asynUser *pasynUser;
     asynStatus status;
@@ -1195,7 +1193,7 @@ static void resetTimer(void *Pvt)
     timeEndPeriod(minPeriodMs);
 }
 
-epicsShareFunc int asynSetMinTimerPeriod(double minPeriod)
+ASYN_API int asynSetMinTimerPeriod(double minPeriod)
 {
     TIMECAPS timeCaps;
     MMRESULT status;
@@ -1220,7 +1218,7 @@ epicsShareFunc int asynSetMinTimerPeriod(double minPeriod)
 
 #else /* _WIN32 */
 
-epicsShareFunc int asynSetMinTimerPeriod(double minPeriod)
+ASYN_API int asynSetMinTimerPeriod(double minPeriod)
 {
     printf("asynSetMinTimerPeriod is not currently supported on this OS\n");
     return -1;
@@ -1244,7 +1242,7 @@ static const iocshArg *const asynSetQueueLockPortTimeoutArgs[] = {
     &asynSetQueueLockPortTimeoutArg0,&asynSetQueueLockPortTimeoutArg1};
 static const iocshFuncDef asynSetQueueLockPortTimeoutDef =
     {"asynSetQueueLockPortTimeout", 2, asynSetQueueLockPortTimeoutArgs};
-epicsShareFunc int
+ASYN_API int
  asynSetQueueLockPortTimeout(const char *portName, double timeout)
 {
     asynUser *pasynUser;

--- a/asyn/miscellaneous/asynShellCommands.h
+++ b/asyn/miscellaneous/asynShellCommands.h
@@ -12,62 +12,61 @@
 #ifndef INCasynShellCommandsh
 #define INCasynShellCommandsh 1
 
-#include <shareLib.h>
 #ifdef __cplusplus
 extern "C" {
 #endif /*__cplusplus*/
 
-epicsShareFunc int
+ASYN_API int
  asynSetOption(const char *portName, int addr, const char *key, const char *val);
-epicsShareFunc int
+ASYN_API int
  asynShowOption(const char *portName, int addr,const char *key);
-epicsShareFunc int
+ASYN_API int
  asynReport(int level, const char *portName);
-epicsShareFunc int
+ASYN_API int
  asynSetTraceMask(const char *portName,int addr,int mask);
-epicsShareFunc int
+ASYN_API int
  asynSetTraceIOMask(const char *portName,int addr,int mask);
-epicsShareFunc int
+ASYN_API int
  asynSetTraceInfoMask(const char *portName,int addr,int mask);
-epicsShareFunc int
+ASYN_API int
  asynSetTraceFile(const char *portName,int addr,const char *filename);
-epicsShareFunc int
+ASYN_API int
  asynSetTraceIOTruncateSize(const char *portName,int addr,int size);
-epicsShareFunc int
+ASYN_API int
  asynAutoConnect(const char *portName,int addr,int yesNo);
-epicsShareFunc int
+ASYN_API int
  asynEnable(const char *portName,int addr,int yesNo);
 
-epicsShareFunc int
+ASYN_API int
  asynOctetConnect(const char *entry, const char *port, int addr,
                   int timeout, int buffer_len,const char *drvInfo);
-epicsShareFunc int
+ASYN_API int
  asynOctetDisconnect(const char *entry);
-epicsShareFunc int
+ASYN_API int
  asynWaitConnect(const char *portName, double timeout);
-epicsShareFunc int
+ASYN_API int
  asynOctetRead(const char *entry, int nread);
-epicsShareFunc int
+ASYN_API int
  asynOctetWrite(const char *entry, const char *output);
-epicsShareFunc int
+ASYN_API int
  asynOctetWriteRead(const char *entry, const char *output, int nread);
-epicsShareFunc int
+ASYN_API int
  asynOctetFlush(const char *entry);
-epicsShareFunc int
+ASYN_API int
  asynOctetSetInputEos(const char *port, int addr,const char *eos);
-epicsShareFunc int
+ASYN_API int
  asynOctetGetInputEos(const char *port, int addr);
-epicsShareFunc int
+ASYN_API int
  asynOctetSetOutputEos(const char *port, int addr,const char *eos);
-epicsShareFunc int
+ASYN_API int
  asynOctetGetOutputEos(const char *port, int addr);
-epicsShareFunc int
+ASYN_API int
  asynRegisterTimeStampSource(const char *portName, const char *functionName);
-epicsShareFunc int
+ASYN_API int
  asynUnregisterTimeStampSource(const char *portName);
-epicsShareFunc int
+ASYN_API int
  asynSetMinTimerPeriod(double period);
-epicsShareFunc int
+ASYN_API int
  asynSetQueueLockPortTimeout(const char *portName, double timeout);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR converts asyn from using the traditional shareLib.h with epicsShareFunc, epicsShareExtern, epicsShareClass, etc. to using the mechanism now used in base.  Added asynAPI.h, modified asyn/Makefile,  and changed code to use the new mechanism.