### PR TITLE
Eliminate use of std::auto_ptr

### DIFF
--- a/asyn/asynPortDriver/asynPortDriver.cpp
+++ b/asyn/asynPortDriver/asynPortDriver.cpp
@@ -129,11 +129,10 @@ asynStatus paramList::createParam(const char *name, asynParamType type, int *ind
 
     if (this->findParam(name, index) == asynSuccess) return asynParamAlreadyExists;
 
-    std::auto_ptr<paramVal> param(new paramVal(name, type));
+    paramVal *param = new paramVal(name, type);
 
-    vals.push_back(param.get());
+    vals.push_back(param);
     flags.reserve(vals.size());
-    param.release();
     *index = (int)vals.size()-1;
     return asynSuccess;
 }


### PR DESCRIPTION
@mdavidsaver in 2014 you improved asynPortDriver by using STL classes.  One of the changes you made was to use the std::auto_ptr class in one place.  std::auto_ptr is now deprecated and will be removed in C++ 17.  I therefore am proposing to remove it in this PR.

Can you comment on this?  What was gained by using std::auto_ptr over this code? Is there a better alternative that will work with older versions of C++?

