### PR TITLE
Output records, asyn:READBACK=1 and late connect

### DIFF
--- a/asyn/devEpics/devAsynFloat64.c
+++ b/asyn/devEpics/devAsynFloat64.c
@@ -664,7 +664,10 @@ static long processAo(aoRecord *pr)
             if (pr->aslo != 0.0) val64 *= pr->aslo;
             val64 += pr->aoff;
             pr->val = val64;
-            pr->udf = 0;
+            if (pr->udf) {
+                pr->udf = 0;
+                recGblResetAlarms(pr);
+            }
         }
     } else if(pr->pact == 0) {
         /* ASLO/AOFF conversion */

--- a/asyn/devEpics/devAsynInt32.c
+++ b/asyn/devEpics/devAsynInt32.c
@@ -987,7 +987,10 @@ static long processAo(aoRecord *pr)
         /* We got a callback from the driver */
         if (pPvt->result.status == asynSuccess) {
             pr->rval = pPvt->result.value;
-            pr->udf = 0;
+            if (pr->udf) {
+                pr->udf = 0;
+                recGblResetAlarms(pr);
+            }
             value = (double)pr->rval + (double)pr->roff;
             if(pr->aslo!=0.0) value *= pr->aslo;
             value += pr->aoff;
@@ -1113,7 +1116,10 @@ static long processLo(longoutRecord *pr)
         /* We got a callback from the driver */
         if (pPvt->result.status == asynSuccess) {
             pr->val = pPvt->result.value;
-            pr->udf = 0;
+            if (pr->udf) {
+                pr->udf = 0;
+                recGblResetAlarms(pr);
+            }
         }
     } else if(pr->pact == 0) {
         pPvt->result.value = pr->val;
@@ -1219,7 +1225,10 @@ static long processBo(boRecord *pr)
         if (pPvt->result.status == asynSuccess) {
             pr->rval = pPvt->result.value;
             pr->val = (pr->rval) ? 1 : 0;
-            pr->udf = 0;
+            if (pr->udf) {
+                pr->udf = 0;
+                recGblResetAlarms(pr);
+            }
         }
     } else if(pr->pact == 0) {
         pPvt->result.value = pr->rval;
@@ -1347,7 +1356,10 @@ static long processMbbo(mbboRecord *pr)
                 /* the raw  is the desired val */
                 pr->val =  (unsigned short)rval;
             }
-            pr->udf = FALSE;
+            if (pr->udf) {
+                pr->udf = 0;
+                recGblResetAlarms(pr);
+            }
         }
     } else if(pr->pact == 0) {
         pPvt->result.value = pr->rval;

--- a/asyn/devEpics/devAsynInt64.c
+++ b/asyn/devEpics/devAsynInt64.c
@@ -719,7 +719,10 @@ static long processLLo(int64outRecord *pr)
         /* We got a callback from the driver */
         if (pPvt->result.status == asynSuccess) {
             pr->val = pPvt->result.value;
-            pr->udf = 0;
+            if (pr->udf) {
+                pr->udf = 0;
+                recGblResetAlarms(pr);
+            }
         }
     } else if(pr->pact == 0) {
         pPvt->result.value = pr->val;
@@ -912,7 +915,10 @@ static long processAo(aoRecord *pr)
         /* We got a callback from the driver */
         if (pPvt->result.status == asynSuccess) {
             value = (double)pPvt->result.value;
-            pr->udf = 0;
+            if (pr->udf) {
+                pr->udf = 0;
+                recGblResetAlarms(pr);
+            }
             if (pr->linr == menuConvertNO_CONVERSION){
                 ; /*do nothing*/
             } else if ((pr->linr == menuConvertLINEAR) ||
@@ -1023,7 +1029,10 @@ static long processLo(longoutRecord *pr)
         /* We got a callback from the driver */
         if (pPvt->result.status == asynSuccess) {
             pr->val = (epicsInt32)pPvt->result.value;
-            pr->udf = 0;
+            if (pr->udf) {
+                pr->udf = 0;
+                recGblResetAlarms(pr);
+            }
         }
     } else if(pr->pact == 0) {
         pPvt->result.value = pr->val;

--- a/asyn/devEpics/devAsynUInt32Digital.c
+++ b/asyn/devEpics/devAsynUInt32Digital.c
@@ -746,7 +746,10 @@ static long processBo(boRecord *pr)
         if (pPvt->result.status == asynSuccess) {
             pr->rval = pPvt->result.value & pr->mask;
             pr->val = (pr->rval) ? 1 : 0;
-            pr->udf = 0;
+            if (pr->udf) {
+                pr->udf = 0;
+                recGblResetAlarms(pr);
+            }
         }
     } else if(pr->pact == 0) {
         pPvt->result.value = pr->rval;;
@@ -851,7 +854,11 @@ static long processLo(longoutRecord *pr)
         /* We got a callback from the driver */
         if (pPvt->result.status == asynSuccess) {
             pr->val = pPvt->result.value & pPvt->mask;
-            pr->udf = 0;
+            if (pr->udf) {
+                pr->udf = 0;
+                pr->nsta = 0;
+                pr->nsev = 0;
+            }
         }
     } else if(pr->pact == 0) {
         pPvt->result.value = pr->val & pPvt->mask;
@@ -979,7 +986,11 @@ static long processMbbo(mbboRecord *pr)
                 /* the raw  is the desired val */
                 pr->val =  (unsigned short)rval;
             }
-            pr->udf = FALSE;
+            if (pr->udf) {
+                pr->udf = 0;
+                pr->nsta = 0;
+                pr->nsev = 0;
+            }
         }
     } else if(pr->pact == 0) {
         pPvt->result.value = pr->rval;
@@ -1081,7 +1092,11 @@ static long initMbboDirect(mbboDirectRecord *pr)
         value &= pr->mask;
         if (pr->shft > 0) value >>= pr->shft;
         pr->val =  (unsigned short) value;
-        pr->udf = FALSE;
+        if (pr->udf) {
+            pr->udf = 0;
+            pr->nsta = 0;
+            pr->nsev = 0;
+        }
         for (i = 0; i < 16; i++) {
             *pBn++ = !! (value & 1);
             value >>= 1;


### PR DESCRIPTION
When an output record is setup with PINI=0 and no VAL is specified
and asyn:READBACK=1 is set, the record will read the value from
the device and put that value into the record.

This works well when the driver has been able to read the value from the
hardware before the record in initialized.

When the driver reads the value (much) later, the normal callback/process
code will put the value into the record, but the record stays in the
"INVALID DRIVER UDF" alarm state (with UDF = 0).

Another process() will trigger the alarm processing (?) and
the record leaves the alarm state.
Note that this process() is only triggered when a new value is read from
the driver, or the VAL field of the record changes, so it may never happen.

Fix this issue for the 32 bit integer records.
Note: int64 and double64 need this fix as well.