### PR TITLE
Add checkws.sh and fix trailing whitespace

### DIFF
--- a/asyn/drvAsynSerial/drvAsynIPPort.c
+++ b/asyn/drvAsynSerial/drvAsynIPPort.c
@@ -85,7 +85,7 @@
 # endif
 #endif
 
-/* If SO_REUSEPORT is not defined then use SO_REUSEADDR instead.  
+/* If SO_REUSEPORT is not defined then use SO_REUSEADDR instead.
    It is not defined on RTEMS, Windows and older Linux versions. */
 #ifndef SO_REUSEPORT
 # define USE_SO_REUSEADDR

--- a/asyn/drvPrologixGPIB/drvPrologixGPIB.c
+++ b/asyn/drvPrologixGPIB/drvPrologixGPIB.c
@@ -570,7 +570,7 @@ prologixGPIBConfigure(const char *portName, const char *host, int priority, int 
     else
         sprintf(pdpvt->hostTCP, "%s:1234 TCP", host);
     drvAsynIPPortConfigure(pdpvt->portNameTCP, pdpvt->hostTCP,
-                                               priority, 
+                                               priority,
                                                1, /* No auto connect  */
                                                1  /* No process EOS */ );
     status = pasynCommonSyncIO->connect(pdpvt->portNameTCP, -1,
@@ -585,7 +585,7 @@ prologixGPIBConfigure(const char *portName, const char *host, int priority, int 
         printf("Can't find ASYN port \"%s\".\n", pdpvt->portNameTCP);
         return;
     }
-     
+
     /*
      * Register as a GPIB driver
      */

--- a/checkws.sh
+++ b/checkws.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# Check if we have any TAB or trailing SPACE in our code base
+#
+
+TAB=$(printf '\t')
+
+fileswscheck=$(git ls-files '*.[ch]' '*.cpp' '*.hpp' '*.sh' '*.py' '*.iocsh')
+if test -n "$fileswscheck"; then
+  cmd=$(printf "%s %s" 'egrep -n "$TAB| \$"' "$fileswscheck")
+  #echo cmd=$cmd
+  eval $cmd
+  if test $? -eq 0; then
+    #TABS found
+    exit 1
+  fi
+fi
+exit 0


### PR DESCRIPTION
Some trailing whitespace have sneaked in - remove them.
Add a checkws.sh script, that can be run manually and later integrated
into a ci script/action.