### PR TITLE
fix hanging format specifiers

### DIFF
--- a/asyn/devEpics/devAsynFloat64.c
+++ b/asyn/devEpics/devAsynFloat64.c
@@ -144,7 +144,7 @@ static long initCommon(dbCommon *pr, DBLINK *plink,
     asynInterface *pasynInterface;
     static const char *functionName="initCommon";
 
-    pPvt = callocMustSucceed(1, sizeof(*pPvt), "%s::%s");
+    pPvt = callocMustSucceed(1, sizeof(*pPvt), "devAsynFloat64::initCommon");
     pr->dpvt = pPvt;
     pPvt->pr = pr;
     /* Create asynUser */
@@ -267,7 +267,7 @@ static long createRingBuffer(dbCommon *pr)
         }
         sizeString = dbGetInfo(pdbentry, "asyn:FIFO");
         if (sizeString) pPvt->ringSize = atoi(sizeString);
-        pPvt->ringBuffer = callocMustSucceed(pPvt->ringSize+1, sizeof *pPvt->ringBuffer, "%s::createRingBuffer");
+        pPvt->ringBuffer = callocMustSucceed(pPvt->ringSize+1, sizeof *pPvt->ringBuffer, "devAsynFloat64::createRingBuffer");
     }
     return asynSuccess;
 }

--- a/asyn/devEpics/devAsynUInt32Digital.c
+++ b/asyn/devEpics/devAsynUInt32Digital.c
@@ -335,7 +335,7 @@ static long createRingBuffer(dbCommon *pr)
         }
         sizeString = dbGetInfo(pdbentry, "asyn:FIFO");
         if (sizeString) pPvt->ringSize = atoi(sizeString);
-        pPvt->ringBuffer = callocMustSucceed(pPvt->ringSize+1, sizeof *pPvt->ringBuffer, "%s::createRingBuffer");
+        pPvt->ringBuffer = callocMustSucceed(pPvt->ringSize+1, sizeof *pPvt->ringBuffer, "devAsynUInt32Digital::createRingBuffer");
     }
     return asynSuccess;
 }


### PR DESCRIPTION
callocMustSucceed last argument is not a format specifier string, it
will be printed as-is. Replace format specifiers with wanted strings.