### PR TITLE
Base asynInterpose implementation

### DIFF
--- a/asyn/Makefile
+++ b/asyn/Makefile
@@ -102,7 +102,7 @@ DBD += asyn.dbd
 INC += asynShellCommands.h
 INC += asynInterposeCom.h
 INC += asynInterposeEos.h
-INC += asynInterposeDummy.h
+INC += asynInterposeTemplate.h
 INC += asynInterposeFlush.h
 ifneq ($(EPICS_LIBCOM_ONLY),YES)
   asyn_SRCS += asynShellCommands.c
@@ -112,7 +112,7 @@ asyn_SRCS += asynInterposeEos.c
 asyn_SRCS += asynInterposeFlush.c
 asyn_SRCS += asynInterposeDelay.c
 asyn_SRCS += asynInterposeEcho.c
-asyn_SRCS += asynInterposeDummy.c
+asyn_SRCS += asynInterposeTemplate.c
 
 SRC_DIRS += $(ASYN)/asynPortDriver/exceptions
 INC += ParamListInvalidIndex.h

--- a/asyn/miscellaneous/asyn.dbd
+++ b/asyn/miscellaneous/asyn.dbd
@@ -3,7 +3,7 @@ registrar(asynInterposeFlushRegister)
 registrar(asynInterposeEosRegister)
 registrar(asynInterposeDelayRegister)
 registrar(asynInterposeEchoRegister)
-registrar(asynInterposeDummyRegister)
+registrar(asynInterposeTemplateRegister)
 
 #
 # The following ties this to EPICS records.

--- a/asyn/miscellaneous/asynInterposeTemplate.c
+++ b/asyn/miscellaneous/asynInterposeTemplate.c
@@ -1,8 +1,8 @@
-/*asynInterposeDummy.c*/
+/*asynInterposeTemplate.c*/
 
 /*
  * Example of an asynInterpose implementation
- * The dummy implementation does *nothing*,
+ * The template implementation does *nothing*,
  * simply forwards requests to the lower port.
  *
  * Use this as as a base example to build your asynInterpose.
@@ -10,22 +10,22 @@
  * Author: davide.marcato@lnl.infn.it
  */
 
-#include "asynInterposeDummy.h"
+#include "asynInterposeTemplate.h"
 
 ASYN_API
-int asynInterposeDummyConfig(const char *portName) {
+int asynInterposeTemplateConfig(const char *portName) {
   interposePvt *pvt;
   asynInterface *plowerLevelInterface;
   asynStatus status;
   asynUser *pasynUser;
   int addr = 0;
-  
+
   // Populate private data
-  pvt = callocMustSucceed(1, sizeof(interposePvt), "asynInterposeDummy");
+  pvt = callocMustSucceed(1, sizeof(interposePvt), "asynInterposeTemplate");
   pvt->portName = epicsStrDup(portName);
-  pvt->dummyInterface.interfaceType = asynOctetType;
-  pvt->dummyInterface.pinterface = &octet;
-  pvt->dummyInterface.drvPvt = pvt;
+  pvt->templateInterface.interfaceType = asynOctetType;
+  pvt->templateInterface.pinterface = &octet;
+  pvt->templateInterface.drvPvt = pvt;
   pasynUser = pasynManager->createAsynUser(0, 0);
   pvt->pasynUser = pasynUser;
   pvt->pasynUser->userPvt = pvt;
@@ -49,8 +49,8 @@ int asynInterposeDummyConfig(const char *portName) {
   }
 
   // Interpose port
-  status =
-      pasynManager->interposeInterface(portName, addr, &pvt->dummyInterface, &plowerLevelInterface);
+  status = pasynManager->interposeInterface(portName, addr, &pvt->templateInterface,
+                                            &plowerLevelInterface);
   if (status != asynSuccess) {
     printf("%s interposeInterface failed\n", portName);
     pasynManager->exceptionCallbackRemove(pasynUser);
@@ -133,20 +133,20 @@ static asynStatus getOutputEos(void *ppvt, asynUser *pasynUser, char *eos, int e
   return pvt->poctet->getOutputEos(pvt->octetPvt, pasynUser, eos, eossize, eoslen);
 }
 
-/* register asynInterposeDummyConfig*/
-static const iocshArg asynInterposeDummyConfigArg0 = {"portName", iocshArgString};
-static const iocshArg *asynInterposeDummyConfigArgs[] = {&asynInterposeDummyConfigArg0};
-static const iocshFuncDef asynInterposeDummyConfigFuncDef = {"asynInterposeDummyConfig", 1,
-                                                             asynInterposeDummyConfigArgs};
-static void asynInterposeDummyConfigCallFunc(const iocshArgBuf *args) {
-  asynInterposeDummyConfig(args[0].sval);
+/* register asynInterposeTemplateConfig*/
+static const iocshArg asynInterposeTemplateConfigArg0 = {"portName", iocshArgString};
+static const iocshArg *asynInterposeTemplateConfigArgs[] = {&asynInterposeTemplateConfigArg0};
+static const iocshFuncDef asynInterposeTemplateConfigFuncDef = {"asynInterposeTemplateConfig", 1,
+                                                                asynInterposeTemplateConfigArgs};
+static void asynInterposeTemplateConfigCallFunc(const iocshArgBuf *args) {
+  asynInterposeTemplateConfig(args[0].sval);
 }
 
-static void asynInterposeDummyRegister(void) {
+static void asynInterposeTemplateRegister(void) {
   static int firstTime = 1;
   if (firstTime) {
     firstTime = 0;
-    iocshRegister(&asynInterposeDummyConfigFuncDef, asynInterposeDummyConfigCallFunc);
+    iocshRegister(&asynInterposeTemplateConfigFuncDef, asynInterposeTemplateConfigCallFunc);
   }
 }
-epicsExportRegistrar(asynInterposeDummyRegister);
+epicsExportRegistrar(asynInterposeTemplateRegister);

--- a/asyn/miscellaneous/asynInterposeTemplate.h
+++ b/asyn/miscellaneous/asynInterposeTemplate.h
@@ -1,8 +1,8 @@
-/*asynInterposeDummy.h*/
+/*asynInterposeTemplate.h*/
 
 /*
  * Example of an asynInterpose implementation
- * The dummy implementation does *nothing*,
+ * The template implementation does *nothing*,
  * simply forwards requests to the lower port.
  *
  * Use this as as a base example to build your asynInterpose.
@@ -10,8 +10,8 @@
  * Author: davide.marcato@lnl.infn.it
  */
 
-#ifndef asynInterposeDummy_H
-#define asynInterposeDummy_H
+#ifndef asynInterposeTemplate_H
+#define asynInterposeTemplate_H
 
 #include <cantProceed.h>
 #include <epicsAssert.h>
@@ -33,14 +33,14 @@ extern "C" {
 // Interpose private data
 typedef struct interposePvt {
   char *portName;
-  asynInterface dummyInterface; /* This asynOctet interface */
-  asynOctet *poctet;            /* The methods we're overriding */
-  void *octetPvt;               /* Private data of next lower interface */
-  asynUser *pasynUser;          /* For connect/disconnect reporting */
+  asynInterface templateInterface; /* This asynOctet interface */
+  asynOctet *poctet;               /* The methods we're overriding */
+  void *octetPvt;                  /* Private data of next lower interface */
+  asynUser *pasynUser;             /* For connect/disconnect reporting */
 } interposePvt;
 
 ASYN_API
-int asynInterposeDummyConfig(const char *portName);
+int asynInterposeTemplateConfig(const char *portName);
 
 /* Connect/disconnect handling */
 static void ExceptionHandler(asynUser *pasynUser, asynException exception);
@@ -68,4 +68,4 @@ static asynOctet octet = {
 }
 #endif /* __cplusplus */
 
-#endif /* asynInterposeDummy_H */
+#endif /* asynInterposeTemplate_H */


### PR DESCRIPTION
Hello,
this adds a base implementation of an ``asynInterpose``, which does _absolutely nothing_. All the requests are passed directly to the underlying port.

This is useful as a guide for new users to implement a new interpose. One can just start from this base implementation and change only the functions that are useful for his use-case. Since I had to implement a custom ``asynInterpose``, this would have saved me a few hours.

I wrote this by looking at the other ``asynInterpose`` implementations but I am not an expert in asyn, so let me know if I missed something.