### PR TITLE
vxi11/osiRpc.h: freebsd does not have rpcTaskInit()

### DIFF
--- a/asyn/vxi11/osiRpc.h
+++ b/asyn/vxi11/osiRpc.h
@@ -46,4 +46,8 @@
 #define rpcTaskInit() 0
 #endif
 
+#ifdef freebsd
+#define rpcTaskInit() 0
+#endif
+
 #endif /* _osiRpcH_ */


### PR DESCRIPTION
One more OS that does not have rpcTaskInit() and needs a