### PR TITLE
vxi11/osiRpc.h: Only RTEMS with RTEMS_LEGACY_STACK needs rpcTaskInit

### DIFF
--- a/asyn/vxi11/osiRpc.h
+++ b/asyn/vxi11/osiRpc.h
@@ -22,7 +22,11 @@
 #ifdef __rtems__
 #include <rpc/pmap_clnt.h>
 #include <rtems.h>
+#ifdef RTEMS_LEGACY_STACK
 #define rpcTaskInit rtems_rpc_task_init
+#else
+#define rpcTaskInit() 0
+#endif
 #endif
 
 #ifdef __APPLE__


### PR DESCRIPTION
Reported by Michael Davidsaver:
With RTEMS 5 for pc686 with the libbsd (aka. "new") network stack I get:
In file included from ../../asyn/vxi11/drvVxi11.c:41:0:
../../asyn/vxi11/drvVxi11.c: In function 'vxiConnectPort':
../../asyn/vxi11/osiRpc.h:25:21: error: implicit declaration of function 'rtems_rpc_task_init'; did you mean 'rtems_task_exit'? [-Werror=implicit-function-declaration]
 #define rpcTaskInit rtems_rpc_task_init
                     ^
../../asyn/vxi11/drvVxi11.c:908:12: note: in expansion of macro 'rpcTaskInit'
         if(rpcTaskInit() == -1) {

================
Solution:
Use RTEMS_LEGACY_STACK to switch between the "old" and "new"
networkstack for RTEMS