### PR TITLE
Reorganize dependency files, and add RTEMS jobs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -92,23 +92,30 @@ environment:
 
   matrix:
   - CMP: vs2019
-    SET: base7
+    BASE: "7.0"
+    SET: "deps2"
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
   - CMP: gcc
-    SET: base7
+    BASE: "7.0"
+    SET: "deps2"
   - CMP: vs2019
-    SET: base3-15
+    BASE: "3.15"
+    SET: "deps2"
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
   - CMP: vs2019
-    SET: base3-14
+    BASE: "3.14"
+    SET: "deps1"
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
   #- CMP: vs2017
-  #  SET: base7
+  #  BASE: "7.0"
+  #  SET: "deps2"
   #  APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
   - CMP: vs2015
-    SET: base7
+    BASE: "7.0"
+    SET: "deps2"
   #- CMP: vs2013
-  #  SET: base7
+  #  BASE: "7.0"
+  #  SET: "deps2"
 
 # Platform: processor architecture
 platform:

--- a/.ci-local/base3-15.set
+++ b/.ci-local/base3-15.set
@@ -1,9 +1,0 @@
-MODULES="sncseq sscan calc ipac"
-
-BASE=3.15
-BASE_RECURSIVE=no
-
-SNCSEQ=R2-2-8
-SSCAN=R2-11-3
-CALC=R3-7-3
-IPAC=2.15

--- a/.ci-local/deps-latest.set
+++ b/.ci-local/deps-latest.set
@@ -1,0 +1,8 @@
+MODULES="sncseq sscan calc ipac"
+
+BASE_RECURSIVE=no
+
+SNCSEQ=master
+SSCAN=master
+CALC=master
+IPAC=master

--- a/.ci-local/deps1.set
+++ b/.ci-local/deps1.set
@@ -1,6 +1,5 @@
 MODULES="sncseq sscan calc ipac"
 
-BASE=3.14
 BASE_RECURSIVE=no
 
 SNCSEQ=R2-2-8

--- a/.ci-local/deps2.set
+++ b/.ci-local/deps2.set
@@ -1,6 +1,5 @@
 MODULES="sncseq sscan calc ipac"
 
-BASE=7.0
 BASE_RECURSIVE=no
 
 SNCSEQ=R2-2-8

--- a/.ci-local/no-deps.set
+++ b/.ci-local/no-deps.set
@@ -1,0 +1,3 @@
+MODULES=""
+
+BASE_RECURSIVE=no

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -13,13 +13,15 @@ env:
 
 jobs:
   test:
-    name: ${{ matrix.os }}/${{ matrix.deps }}/${{ matrix.base }}/${{ matrix.cmp }}/${{ matrix.configuration }}
+    name: ${{ matrix.os }}/${{ matrix.deps }}/${{ matrix.base }}/${{ matrix.cmp }}/${{ matrix.configuration }}/${{ matrix.cross }}
     runs-on: ${{ matrix.os }}
     env:
       CMP: ${{ matrix.cmp }}
       BCFG: ${{ matrix.configuration }}
       BASE: ${{ matrix.base }}
       SET: ${{ matrix.deps }}
+      CI_CROSS_TARGETS: ${{ matrix.cross }}
+      TEST: ${{ matrix.test }}
       APT: re2c
       CHOCO: re2c
       BREW: re2c
@@ -33,48 +35,71 @@ jobs:
             cmp: gcc
             configuration: default
             base: "7.0"
-            deps: "base7"
+            deps: "deps2"
 
           - os: ubuntu-latest
             cmp: gcc
             configuration: static
             base: "7.0"
-            deps: "base7"
+            deps: "deps2"
 
           - os: ubuntu-latest
             cmp: gcc
             configuration: static
             base: "7.0"
-            deps: "base7"
+            deps: "deps2"
 
           - os: ubuntu-latest
             cmp: gcc
             configuration: default
             base: "3.15"
+            deps: "no-deps"
 
           - os: ubuntu-latest
             cmp: gcc
             configuration: static
             base: "3.15"
-            deps: "base3-15"
+            deps: "deps2"
 
           - os: ubuntu-latest
             cmp: gcc
             configuration: static
             base: "3.14"
-            deps: "base3-14"
+            deps: "deps1"
 
           - os: windows-2019
             cmp: vs2019
             configuration: default
             base: "7.0"
-            deps: "base7"
+            deps: "deps2"
 
           - os: windows-2019
             cmp: vs2019
             configuration: static
             base: "7.0"
-            deps: "base7"
+            deps: "deps2"
+
+          - os: ubuntu-latest
+            cmp: gcc
+            configuration: default
+            base: "7.0"
+            deps: "no-deps"
+            cross: "RTEMS-pc386-qemu@4.9"
+
+          - os: ubuntu-latest
+            cmp: gcc
+            configuration: default
+            base: "7.0"
+            deps: "no-deps"
+            cross: "RTEMS-pc386-qemu@4.10"
+            test: NO
+
+#          - os: ubuntu-latest
+#            cmp: gcc
+#            configuration: default
+#            base: "7.0"
+#            deps: "no-deps"
+#            cross: "RTEMS-pc686-qemu@5"
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
The `BASE` version also given in the .yml, so the definition in the `.set` files isn't used.  So these can be removed, and the `.set` files reorganized to be strictly about the build dependencies.  I've also added a new set to build a new `.set` with the latest version of all four dependencies.

Also, added RTEMS 4.9 and 4.10 x86 jobs.  I've left in a commented entry for RTEMS 5, which currently fails.  This could be uncommented to test #153.