### PR TITLE
GHA update

### DIFF
--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -101,12 +101,15 @@ jobs:
 #            deps: "no-deps"
 #            cross: "RTEMS-pc686-qemu@5"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
     - name: Prepare and compile EPICS dependencies
       run: python .ci/cue.py prepare
+
+    - name: TIRPC
+      run: echo TIRPC=YES > configure/CONFIG_SITE.Common.linux-x86_64
 
     - name: Build main module
       run: python .ci/cue.py build
@@ -116,7 +119,7 @@ jobs:
 
     - name: Upload tapfiles Artifact
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: tapfiles ${{ matrix.name }}
         path: '**/O.*/*.tap'


### PR DESCRIPTION
GHA builds on `ubuntu-latest` are currently failing for lack of `TIRPC=YES`.  Also, update some actions to avoid deprecation warnings.

Is it time to drop the 3.14 job?

The `BASE=3.14` job continues to fail while building epics-base with an error which I don't understand.  I am able to successfully build the 3.14 branch locally.  Recent [advice on tech-talk](https://epics.anl.gov/tech-talk/2022/msg01561.php) is that `The 3.14 release series is dead ...`.

```
...
  In file included from ../../../../src/cas/generic/caServer.cc:21:
  ../../../../src/cas/generic/caServerI.h:92:5: error: ‘class tsDLList<ioBlocked> tsDLList<ioBlocked>::tsDLList’ is private within this context
     92 |     tsDLList < casIntfOS > intfList;
        |     ^~~~~~~~~~~~~~~~~~~~~~
  In file included from ../../../../src/cas/generic/caServerI.h:33,
                   from ../../../../src/cas/generic/caServer.cc:21:
  ../../../../src/cas/generic/ioBlocked.h:43:7: note: declared private here
     43 | class ioBlockedList : private tsDLList<ioBlocked> {
        |       ^~~~~~~~~~~~~
```