### PR TITLE
asynDbGetInfo: consolidate dbGetInfo and plug leak at init

### DIFF
--- a/asyn/Makefile
+++ b/asyn/Makefile
@@ -168,6 +168,7 @@ ifneq ($(EPICS_LIBCOM_ONLY),YES)
   asyn_SRCS += devAsynFloat64.c
   asyn_SRCS += devAsynXXXArray.cpp
   asyn_SRCS += devAsynFloat64TimeSeries.c
+  asyn_SRCS += devEpicsPvt.c
 
   # These require 64-bit support
   ifdef BASE_7_0

--- a/asyn/devEpics/devAsynFloat64.c
+++ b/asyn/devEpics/devAsynFloat64.c
@@ -42,6 +42,7 @@
 #include "asynFloat64SyncIO.h"
 #include "asynEpicsUtils.h"
 #include "asynFloat64.h"
+#include "devEpicsPvt.h"
 
 #define INIT_OK 0
 #define INIT_DO_NOT_CONVERT 2
@@ -214,16 +215,7 @@ static long initCommon(dbCommon *pr, DBLINK *plink,
      * then register for callbacks on output records */
     if (interruptCallback) {
         int enableCallbacks=0;
-        const char *callbackString;
-        DBENTRY *pdbentry = dbAllocEntry(pdbbase);
-        status = dbFindRecord(pdbentry, pr->name);
-        if (status) {
-            asynPrint(pPvt->pasynUser, ASYN_TRACE_ERROR,
-                "%s %s::%s error finding record\n",
-                pr->name, driverName, functionName);
-            goto bad;
-        }
-        callbackString = dbGetInfo(pdbentry, "asyn:READBACK");
+        const char *callbackString = asynDbGetInfo(pr, "asyn:READBACK");
         if (callbackString) enableCallbacks = atoi(callbackString);
         if (enableCallbacks) {
             status = createRingBuffer(pr);
@@ -256,16 +248,8 @@ static long createRingBuffer(dbCommon *pr)
     static const char *functionName="createRingBuffer";
 
     if (!pPvt->ringBuffer) {
-        DBENTRY *pdbentry = dbAllocEntry(pdbbase);
         pPvt->ringSize = DEFAULT_RING_BUFFER_SIZE;
-        status = dbFindRecord(pdbentry, pr->name);
-        if (status) {
-            asynPrint(pPvt->pasynUser, ASYN_TRACE_ERROR,
-                "%s %s::%s error finding record\n",
-                pr->name, driverName, functionName);
-            return -1;
-        }
-        sizeString = dbGetInfo(pdbentry, "asyn:FIFO");
+        sizeString = asynDbGetInfo(pr, "asyn:FIFO");
         if (sizeString) pPvt->ringSize = atoi(sizeString);
         pPvt->ringBuffer = callocMustSucceed(pPvt->ringSize+1, sizeof *pPvt->ringBuffer, "devAsynFloat64::createRingBuffer");
     }

--- a/asyn/devEpics/devAsynInt32.c
+++ b/asyn/devEpics/devAsynInt32.c
@@ -54,6 +54,7 @@
 #include "asynEnum.h"
 #include "asynEnumSyncIO.h"
 #include "asynEpicsUtils.h"
+#include "devEpicsPvt.h"
 
 #define INIT_OK 0
 #define INIT_DO_NOT_CONVERT 2
@@ -325,16 +326,7 @@ static long initCommon(dbCommon *pr, DBLINK *plink,
      * then register for callbacks on output records */
     if (interruptCallback) {
         int enableCallbacks=0;
-        const char *callbackString;
-        DBENTRY *pdbentry = dbAllocEntry(pdbbase);
-        status = dbFindRecord(pdbentry, pr->name);
-        if (status) {
-            asynPrint(pPvt->pasynUser, ASYN_TRACE_ERROR,
-                "%s %s::%s error finding record\n",
-                pr->name, driverName, functionName);
-            goto bad;
-        }
-        callbackString = dbGetInfo(pdbentry, "asyn:READBACK");
+        const char *callbackString = asynDbGetInfo(pr, "asyn:READBACK");
         if (callbackString) enableCallbacks = atoi(callbackString);
         if (enableCallbacks) {
             status = createRingBuffer(pr);
@@ -367,16 +359,8 @@ static long createRingBuffer(dbCommon *pr)
     static const char *functionName="createRingBuffer";
 
     if (!pPvt->ringBuffer) {
-        DBENTRY *pdbentry = dbAllocEntry(pdbbase);
         pPvt->ringSize = DEFAULT_RING_BUFFER_SIZE;
-        status = dbFindRecord(pdbentry, pr->name);
-        if (status) {
-            asynPrint(pPvt->pasynUser, ASYN_TRACE_ERROR,
-                "%s %s::%s error finding record\n",
-                pr->name, driverName, functionName);
-            return -1;
-        }
-        sizeString = dbGetInfo(pdbentry, "asyn:FIFO");
+        sizeString = asynDbGetInfo(pr, "asyn:FIFO");
         if (sizeString) pPvt->ringSize = atoi(sizeString);
         pPvt->ringBuffer = callocMustSucceed(pPvt->ringSize+1, sizeof *pPvt->ringBuffer, "devAsynInt32::createRingBuffer");
     }

--- a/asyn/devEpics/devAsynUInt32Digital.c
+++ b/asyn/devEpics/devAsynUInt32Digital.c
@@ -51,6 +51,7 @@
 #include "asynEnum.h"
 #include "asynEnumSyncIO.h"
 #include "asynEpicsUtils.h"
+#include "devEpicsPvt.h"
 
 #define INIT_OK 0
 #define INIT_DO_NOT_CONVERT 2
@@ -282,16 +283,7 @@ static long initCommon(dbCommon *pr, DBLINK *plink,
      * then register for callbacks on output records */
     if (interruptCallback) {
         int enableCallbacks=0;
-        const char *callbackString;
-        DBENTRY *pdbentry = dbAllocEntry(pdbbase);
-        status = dbFindRecord(pdbentry, pr->name);
-        if (status) {
-            asynPrint(pPvt->pasynUser, ASYN_TRACE_ERROR,
-                "%s %s::%s error finding record\n",
-                pr->name, driverName, functionName);
-            goto bad;
-        }
-        callbackString = dbGetInfo(pdbentry, "asyn:READBACK");
+        const char *callbackString = asynDbGetInfo(pr, "asyn:READBACK");
         if (callbackString) enableCallbacks = atoi(callbackString);
         if (enableCallbacks) {
             status = createRingBuffer(pr);
@@ -324,16 +316,8 @@ static long createRingBuffer(dbCommon *pr)
     static const char *functionName="createRingBuffer";
 
     if (!pPvt->ringBuffer) {
-        DBENTRY *pdbentry = dbAllocEntry(pdbbase);
         pPvt->ringSize = DEFAULT_RING_BUFFER_SIZE;
-        status = dbFindRecord(pdbentry, pr->name);
-        if (status) {
-            asynPrint(pPvt->pasynUser, ASYN_TRACE_ERROR,
-                "%s %s::%s error finding record\n",
-                pr->name, driverName, functionName);
-            return -1;
-        }
-        sizeString = dbGetInfo(pdbentry, "asyn:FIFO");
+        sizeString = asynDbGetInfo(pr, "asyn:FIFO");
         if (sizeString) pPvt->ringSize = atoi(sizeString);
         pPvt->ringBuffer = callocMustSucceed(pPvt->ringSize+1, sizeof *pPvt->ringBuffer, "devAsynUInt32Digital::createRingBuffer");
     }

--- a/asyn/devEpics/devAsynXXXArray.cpp
+++ b/asyn/devEpics/devAsynXXXArray.cpp
@@ -38,6 +38,7 @@
 #include <asynInt64Array.h>
 #include <asynFloat32Array.h>
 #include <asynFloat64Array.h>
+#include "devEpicsPvt.h"
 
 #define DEFAULT_RING_BUFFER_SIZE 0
 #define INIT_OK 0
@@ -159,16 +160,7 @@ public:
          * then register for callbacks on output records */
         if (isOutput_) {
             int enableCallbacks=0;
-            const char *callbackString;
-            DBENTRY *pdbentry = dbAllocEntry(pdbbase);
-            status = dbFindRecord(pdbentry, pRecord_->name);
-            if (status) {
-                asynPrint(pasynUser_, ASYN_TRACE_ERROR,
-                    "%s %s::%s error finding record\n",
-                    pRecord_->name, driverName, functionName);
-                goto bad;
-            }
-            callbackString = dbGetInfo(pdbentry, "asyn:READBACK");
+            const char *callbackString = asynDbGetInfo((dbCommon*)pRecord_, "asyn:READBACK");
             if (callbackString) enableCallbacks = atoi(callbackString);
             if (enableCallbacks) {
                 status = createRingBuffer();

--- a/asyn/devEpics/devEpicsPvt.c
+++ b/asyn/devEpics/devEpicsPvt.c
@@ -1,0 +1,36 @@
+/***********************************************************************
+* Copyright (c) 2023 Michael Davidsaver
+* asynDriver is distributed subject to a Software License Agreement
+* found in file LICENSE that is included with this distribution.
+***********************************************************************/
+
+#include <epicsAssert.h>
+
+#include <epicsVersion.h>
+#include <dbStaticLib.h>
+#include <dbAccess.h>
+
+#include <asynDriver.h>
+#include "devEpicsPvt.h"
+
+#if EPICS_VERSION_INT < VERSION_INT(3, 16, 1, 0)
+static
+void dbInitEntryFromRecord(struct dbCommon *prec,
+                           struct dbEntry *pdbentry)
+{
+    long status;
+    dbInitEntry(pdbbase, pdbentry);
+    status = dbFindRecord(pdbentry, prec->name);
+    assert(!status); /* we have dbCommon* so the record must exist */
+}
+#endif
+
+const char* asynDbGetInfo(struct dbCommon *prec, const char *infoname)
+{
+    const char *ret = NULL;
+    DBENTRY ent;
+    dbInitEntryFromRecord(prec, &ent);
+    ret = dbGetInfo(&ent, infoname);
+    dbFinishEntry(&ent);
+    return ret;
+}

--- a/asyn/devEpics/devEpicsPvt.h
+++ b/asyn/devEpics/devEpicsPvt.h
@@ -1,0 +1,22 @@
+/***********************************************************************
+* Copyright (c) 2023 Michael Davidsaver
+* asynDriver is distributed subject to a Software License Agreement
+* found in file LICENSE that is included with this distribution.
+***********************************************************************/
+
+#ifndef DEVEPICSPVT_H
+#define DEVEPICSPVT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct dbCommon;
+
+const char* asynDbGetInfo(struct dbCommon *prec, const char *infoname);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // DEVEPICSPVT_H


### PR DESCRIPTION
Avoid leaking `DBENTRY` during initialization.

Prefer constant time `dbInitEntryFromRecord()` to `dbFindRecord()` when available.

Introduce devEpicsPvt.h/.c to avoid some duplication