### PR TITLE
Destructible ports

### DIFF
--- a/asyn/asynDriver/asynDriver.h
+++ b/asyn/asynDriver/asynDriver.h
@@ -52,7 +52,8 @@ typedef enum {
 typedef enum {
     asynExceptionConnect,asynExceptionEnable,asynExceptionAutoConnect,
     asynExceptionTraceMask,asynExceptionTraceIOMask,asynExceptionTraceInfoMask,
-    asynExceptionTraceFile,asynExceptionTraceIOTruncateSize
+    asynExceptionTraceFile,asynExceptionTraceIOTruncateSize,
+    asynExceptionShutdown
 } asynException;
 
 #define ASYN_EXCEPTION_STRINGS                                                          \
@@ -93,6 +94,7 @@ typedef struct asynInterface{
 /*registerPort attributes*/
 #define ASYN_MULTIDEVICE  0x0001
 #define ASYN_CANBLOCK     0x0002
+#define ASYN_DESTRUCTIBLE 0x0004
 
 /*standard values for asynUser.reason*/
 #define ASYN_REASON_SIGNAL -1
@@ -156,6 +158,7 @@ typedef struct asynManager {
                               asynInterface *pasynInterface,
                               asynInterface **ppPrev);
     asynStatus (*enable)(asynUser *pasynUser,int yesNo);
+    asynStatus (*shutdown)(asynUser *pasynUser);
     asynStatus (*autoConnect)(asynUser *pasynUser,int yesNo);
     asynStatus (*isConnected)(asynUser *pasynUser,int *yesNo);
     asynStatus (*isEnabled)(asynUser *pasynUser,int *yesNo);

--- a/asyn/asynDriver/asynDriver.h
+++ b/asyn/asynDriver/asynDriver.h
@@ -158,7 +158,7 @@ typedef struct asynManager {
                               asynInterface *pasynInterface,
                               asynInterface **ppPrev);
     asynStatus (*enable)(asynUser *pasynUser,int yesNo);
-    asynStatus (*shutdown)(asynUser *pasynUser);
+    asynStatus (*shutdownPort)(asynUser *pasynUser);
     asynStatus (*autoConnect)(asynUser *pasynUser,int yesNo);
     asynStatus (*isConnected)(asynUser *pasynUser,int *yesNo);
     asynStatus (*isEnabled)(asynUser *pasynUser,int *yesNo);

--- a/asyn/asynDriver/asynManager.c
+++ b/asyn/asynDriver/asynManager.c
@@ -2016,19 +2016,7 @@ static void destroyPortDriver(void *portName) {
         pasynManager->freeAsynUser(pasynUser);
         return;
     }
-    status = pasynManager->lockPort(pasynUser);
-    if(status != asynSuccess) {
-        if (status != asynDisabled) {
-            printf("%s\n", pasynUser->errorMessage);
-        }
-        pasynManager->freeAsynUser(pasynUser);
-        return;
-    }
     status = pasynManager->shutdownPort(pasynUser);
-    if(status != asynSuccess) {
-        printf("%s\n", pasynUser->errorMessage);
-    }
-    status = pasynManager->unlockPort(pasynUser);
     if(status != asynSuccess) {
         printf("%s\n", pasynUser->errorMessage);
     }

--- a/asyn/asynDriver/asynManager.c
+++ b/asyn/asynDriver/asynManager.c
@@ -310,7 +310,7 @@ static asynStatus exceptionDisconnect(asynUser *pasynUser);
 static asynStatus interposeInterface(const char *portName, int addr,
     asynInterface *pasynInterface,asynInterface **ppPrev);
 static asynStatus enable(asynUser *pasynUser,int yesNo);
-static asynStatus shutdown(asynUser *pasynUser);
+static asynStatus shutdownPort(asynUser *pasynUser);
 static asynStatus autoConnectAsyn(asynUser *pasynUser,int yesNo);
 static asynStatus isConnected(asynUser *pasynUser,int *yesNo);
 static asynStatus isEnabled(asynUser *pasynUser,int *yesNo);
@@ -368,7 +368,7 @@ static asynManager manager = {
     exceptionDisconnect,
     interposeInterface,
     enable,
-    shutdown,
+    shutdownPort,
     autoConnectAsyn,
     isConnected,
     isEnabled,
@@ -2001,7 +2001,7 @@ static void destroyPortDriver(void *portName) {
         pasynManager->freeAsynUser(pasynUser);
         return;
     }
-    status = pasynManager->shutdown(pasynUser);
+    status = pasynManager->shutdownPort(pasynUser);
     if(status != asynSuccess) {
         printf("%s\n", pasynUser->errorMessage);
     }
@@ -2215,7 +2215,7 @@ static asynStatus enable(asynUser *pasynUser,int yesNo)
     return asynSuccess;
 }
 
-static asynStatus shutdown(asynUser *pasynUser)
+static asynStatus shutdownPort(asynUser *pasynUser)
 {
     userPvt    *puserPvt = asynUserToUserPvt(pasynUser);
     port       *pport = puserPvt->pport;
@@ -2224,7 +2224,7 @@ static asynStatus shutdown(asynUser *pasynUser)
 
     if (!pport || !pdpCommon) {
         epicsSnprintf(pasynUser->errorMessage,pasynUser->errorMessageSize,
-            "asynManager:shutdown: not connected");
+            "asynManager:shutdownPort: not connected");
         return asynError;
     }
 
@@ -2234,7 +2234,7 @@ static asynStatus shutdown(asynUser *pasynUser)
 
     if (!(pport->attributes & ASYN_DESTRUCTIBLE)) {
         epicsSnprintf(pasynUser->errorMessage,pasynUser->errorMessageSize,
-            "asynManager:shutdown: port does not support shutting down");
+            "asynManager:shutdownPort: port does not support shutting down");
         return asynError;
     }
 

--- a/asyn/asynDriver/asynManager.c
+++ b/asyn/asynDriver/asynManager.c
@@ -2238,14 +2238,18 @@ static asynStatus shutdown(asynUser *pasynUser)
         return asynError;
     }
 
-    // Disabling the port short-circuits queueRequest(), preventing usage of
-    // external asynUser instances that will shortly become dangling references.
-    // It is marked defunct so it cannot be re-enabled.
+    /*
+     * Disabling the port short-circuits queueRequest(), preventing usage of
+     * external asynUser instances that will shortly become dangling references.
+     * It is marked defunct so it cannot be re-enabled.
+     */
     pdpCommon->enabled = FALSE;
     pdpCommon->defunct = TRUE;
 
-    // Nullifying the private pointers to the driver enables trapping on
-    // erroneous accesses, making finding bugs easier.
+    /*
+     * Nullifying the private pointers to the driver enables trapping on
+     * erroneous accesses, making finding bugs easier.
+     */
     pport->pasynLockPortNotify = NULL;
     pport->lockPortNotifyPvt = NULL;
     pinterfaceNode = (interfaceNode *)ellFirst(&pport->interfaceList);
@@ -2255,8 +2259,10 @@ static asynStatus shutdown(asynUser *pasynUser)
         pinterfaceNode = (interfaceNode *)ellNext(&pinterfaceNode->node);
     }
 
-    // Actual destruction of the driver is delegated to the driver itself, which
-    // shall implement an exception handler.
+    /*
+     * Actual destruction of the driver is delegated to the driver itself, which
+     * shall implement an exception handler.
+     */
     exceptionOccurred(pasynUser, asynExceptionShutdown);
 
     return asynSuccess;

--- a/asyn/asynDriver/asynManager.c
+++ b/asyn/asynDriver/asynManager.c
@@ -2219,9 +2219,7 @@ static asynStatus shutdown(asynUser *pasynUser)
     }
 
     if (pdpCommon->defunct) {
-        epicsSnprintf(pasynUser->errorMessage,pasynUser->errorMessageSize,
-            "asynManager:shutdown: port is already shut down");
-        return asynDisabled;
+        return asynSuccess;
     }
 
     if (!(pport->attributes & ASYN_DESTRUCTIBLE)) {

--- a/asyn/asynDriver/asynManager.c
+++ b/asyn/asynDriver/asynManager.c
@@ -1323,8 +1323,16 @@ static asynStatus connectDevice(asynUser *pasynUser,
     const char *portName, int addr)
 {
     userPvt *puserPvt = asynUserToUserPvt(pasynUser);
-    port    *pport = locatePort(portName);
+    port    *pport;
     device  *pdevice;
+
+    if(!portName) {
+        epicsSnprintf(pasynUser->errorMessage,pasynUser->errorMessageSize,
+                "asynManager:connectDevice no port name provided");
+        return asynError;
+    }
+
+    pport = locatePort(portName);
 
     if(!pport) {
         epicsSnprintf(pasynUser->errorMessage,pasynUser->errorMessageSize,

--- a/asyn/asynPortDriver/asynPortDriver.cpp
+++ b/asyn/asynPortDriver/asynPortDriver.cpp
@@ -3943,10 +3943,20 @@ asynStatus asynPortDriver::createParams()
     return asynSuccess;
 }
 
+/** Returns `true` when the port is destructible and `shutdown()` wasn't run yet. */
 bool asynPortDriver::needsShutdown() {
     return shutdownNeeded;
 }
 
+/** Performs cleanup that cannot be done in a destructor.
+ *
+ * The destructor is limited in what it can do because the object is already
+ * partially destroyed. This function has no such limitation. However, it is not
+ * a destructor, and must not leave dangling references; the driver must be left
+ * in a consistent state, allowing the destructor to run.
+ *
+ * When overridden, this function must call the base class implementation.
+ */
 void asynPortDriver::shutdown() {
     // There is a possibility that the destructor is running because we are
     // being directly deleted by user code, without going through asynManager.

--- a/asyn/asynPortDriver/asynPortDriver.cpp
+++ b/asyn/asynPortDriver/asynPortDriver.cpp
@@ -1944,6 +1944,10 @@ paramList* asynPortDriver::getParamList(int list)
 extern "C" {static asynStatus readInt32(void *drvPvt, asynUser *pasynUser,
                             epicsInt32 *value)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -1990,6 +1994,10 @@ asynStatus asynPortDriver::readInt32(asynUser *pasynUser, epicsInt32 *value)
 extern "C" {static asynStatus writeInt32(void *drvPvt, asynUser *pasynUser,
                             epicsInt32 value)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2037,6 +2045,10 @@ asynStatus asynPortDriver::writeInt32(asynUser *pasynUser, epicsInt32 value)
 extern "C" {static asynStatus getBounds(void *drvPvt, asynUser *pasynUser,
                             epicsInt32 *low, epicsInt32 *high)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2071,6 +2083,10 @@ asynStatus asynPortDriver::getBounds(asynUser *pasynUser,
 extern "C" {static asynStatus readInt64(void *drvPvt, asynUser *pasynUser,
                             epicsInt64 *value)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2117,6 +2133,10 @@ asynStatus asynPortDriver::readInt64(asynUser *pasynUser, epicsInt64 *value)
 extern "C" {static asynStatus writeInt64(void *drvPvt, asynUser *pasynUser,
                             epicsInt64 value)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2164,6 +2184,10 @@ asynStatus asynPortDriver::writeInt64(asynUser *pasynUser, epicsInt64 value)
 extern "C" {static asynStatus getBounds64(void *drvPvt, asynUser *pasynUser,
                             epicsInt64 *low, epicsInt64 *high)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2198,6 +2222,10 @@ asynStatus asynPortDriver::getBounds64(asynUser *pasynUser,
 extern "C" {static asynStatus readUInt32Digital(void *drvPvt, asynUser *pasynUser,
                             epicsUInt32 *value, epicsUInt32 mask)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2245,6 +2273,10 @@ asynStatus asynPortDriver::readUInt32Digital(asynUser *pasynUser, epicsUInt32 *v
 extern "C" {static asynStatus writeUInt32Digital(void *drvPvt, asynUser *pasynUser,
                             epicsUInt32 value, epicsUInt32 mask)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2292,6 +2324,10 @@ asynStatus asynPortDriver::writeUInt32Digital(asynUser *pasynUser, epicsUInt32 v
 
 extern "C" {static asynStatus setInterruptUInt32Digital(void *drvPvt, asynUser *pasynUser, epicsUInt32 mask, interruptReason reason)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2335,6 +2371,10 @@ asynStatus asynPortDriver::setInterruptUInt32Digital(asynUser *pasynUser, epicsU
 
 extern "C" {static asynStatus clearInterruptUInt32Digital(void *drvPvt, asynUser *pasynUser, epicsUInt32 mask)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2377,6 +2417,10 @@ asynStatus asynPortDriver::clearInterruptUInt32Digital(asynUser *pasynUser, epic
 
 extern "C" {static asynStatus getInterruptUInt32Digital(void *drvPvt, asynUser *pasynUser, epicsUInt32 *mask, interruptReason reason)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2422,6 +2466,10 @@ asynStatus asynPortDriver::getInterruptUInt32Digital(asynUser *pasynUser, epicsU
 extern "C" {static asynStatus readFloat64(void *drvPvt, asynUser *pasynUser,
                               epicsFloat64 *value)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2474,6 +2522,10 @@ asynStatus asynPortDriver::readFloat64(asynUser *pasynUser, epicsFloat64 *value)
 extern "C" {static asynStatus writeFloat64(void *drvPvt, asynUser *pasynUser,
                               epicsFloat64 value)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2524,6 +2576,10 @@ extern "C" {static asynStatus readOctet(void *drvPvt, asynUser *pasynUser,
                             char *value, size_t maxChars, size_t *nActual,
                             int *eomReason)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2578,6 +2634,10 @@ asynStatus asynPortDriver::readOctet(asynUser *pasynUser,
 extern "C" {static asynStatus writeOctet(void *drvPvt, asynUser *pasynUser,
                               const char *value, size_t maxChars, size_t *nActual)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2628,6 +2688,10 @@ asynStatus asynPortDriver::writeOctet(asynUser *pasynUser, const char *value,
 
 extern "C" {static asynStatus flushOctet(void *drvPvt, asynUser *pasynUser)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2665,6 +2729,10 @@ asynStatus asynPortDriver::flushOctet(asynUser *pasynUser)
 extern "C" {static asynStatus setInputEosOctet(void *drvPvt, asynUser *pasynUser,
                                 const char *eos, int eosLen)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2692,6 +2760,10 @@ asynStatus asynPortDriver::setInputEosOctet(asynUser *pasynUser, const char *eos
 extern "C" {static asynStatus getInputEosOctet(void *drvPvt, asynUser *pasynUser,
                                 char *eos, int eosSize, int *eosLen)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2719,6 +2791,10 @@ asynStatus asynPortDriver::getInputEosOctet(asynUser *pasynUser, char *eos, int 
 extern "C" {static asynStatus setOutputEosOctet(void *drvPvt, asynUser *pasynUser,
                                 const char *eos, int eosLen)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2746,6 +2822,10 @@ asynStatus asynPortDriver::setOutputEosOctet(asynUser *pasynUser, const char *eo
 extern "C" {static asynStatus getOutputEosOctet(void *drvPvt, asynUser *pasynUser,
                                 char *eos, int eosSize, int *eosLen)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2777,6 +2857,10 @@ asynStatus asynPortDriver::getOutputEosOctet(asynUser *pasynUser, char *eos, int
 extern "C" {static asynStatus readInt8Array(void *drvPvt, asynUser *pasynUser, epicsInt8 *value,
                                 size_t nElements, size_t *nIn)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2802,6 +2886,10 @@ asynStatus asynPortDriver::readInt8Array(asynUser *pasynUser, epicsInt8 *value,
 extern "C" {static asynStatus writeInt8Array(void *drvPvt, asynUser *pasynUser, epicsInt8 *value,
                                 size_t nElements)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2840,6 +2928,10 @@ asynStatus asynPortDriver::doCallbacksInt8Array(epicsInt8 *value,
 extern "C" {static asynStatus readInt16Array(void *drvPvt, asynUser *pasynUser, epicsInt16 *value,
                                 size_t nElements, size_t *nIn)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2865,6 +2957,10 @@ asynStatus asynPortDriver::readInt16Array(asynUser *pasynUser, epicsInt16 *value
 extern "C" {static asynStatus writeInt16Array(void *drvPvt, asynUser *pasynUser, epicsInt16 *value,
                                 size_t nElements)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2903,6 +2999,10 @@ asynStatus asynPortDriver::doCallbacksInt16Array(epicsInt16 *value,
 extern "C" {static asynStatus readInt32Array(void *drvPvt, asynUser *pasynUser, epicsInt32 *value,
                                 size_t nElements, size_t *nIn)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2928,6 +3028,10 @@ asynStatus asynPortDriver::readInt32Array(asynUser *pasynUser, epicsInt32 *value
 extern "C" {static asynStatus writeInt32Array(void *drvPvt, asynUser *pasynUser, epicsInt32 *value,
                                 size_t nElements)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2966,6 +3070,10 @@ asynStatus asynPortDriver::doCallbacksInt32Array(epicsInt32 *value,
 extern "C" {static asynStatus readInt64Array(void *drvPvt, asynUser *pasynUser, epicsInt64 *value,
                                 size_t nElements, size_t *nIn)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -2991,6 +3099,10 @@ asynStatus asynPortDriver::readInt64Array(asynUser *pasynUser, epicsInt64 *value
 extern "C" {static asynStatus writeInt64Array(void *drvPvt, asynUser *pasynUser, epicsInt64 *value,
                                 size_t nElements)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -3029,6 +3141,10 @@ asynStatus asynPortDriver::doCallbacksInt64Array(epicsInt64 *value,
 extern "C" {static asynStatus readFloat32Array(void *drvPvt, asynUser *pasynUser, epicsFloat32 *value,
                                 size_t nElements, size_t *nIn)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -3054,6 +3170,10 @@ asynStatus asynPortDriver::readFloat32Array(asynUser *pasynUser, epicsFloat32 *v
 extern "C" {static asynStatus writeFloat32Array(void *drvPvt, asynUser *pasynUser, epicsFloat32 *value,
                                 size_t nElements)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -3092,6 +3212,10 @@ asynStatus asynPortDriver::doCallbacksFloat32Array(epicsFloat32 *value,
 extern "C" {static asynStatus readFloat64Array(void *drvPvt, asynUser *pasynUser, epicsFloat64 *value,
                                 size_t nElements, size_t *nIn)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -3117,6 +3241,10 @@ asynStatus asynPortDriver::readFloat64Array(asynUser *pasynUser, epicsFloat64 *v
 extern "C" {static asynStatus writeFloat64Array(void *drvPvt, asynUser *pasynUser, epicsFloat64 *value,
                                 size_t nElements)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -3153,6 +3281,10 @@ asynStatus asynPortDriver::doCallbacksFloat64Array(epicsFloat64 *value,
 /* asynGenericPointer interface methods */
 extern "C" {static asynStatus readGenericPointer(void *drvPvt, asynUser *pasynUser, void *genericPointer)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -3176,6 +3308,10 @@ asynStatus asynPortDriver::readGenericPointer(asynUser *pasynUser, void *generic
 
 extern "C" {static asynStatus writeGenericPointer(void *drvPvt, asynUser *pasynUser, void *genericPointer)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -3244,6 +3380,10 @@ asynStatus asynPortDriver::doCallbacksGenericPointer(void *genericPointer, int r
 /* asynOption interface methods */
 extern "C" {static asynStatus readOption(void *drvPvt, asynUser *pasynUser, const char *key, char *value, int maxChars)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -3269,6 +3409,10 @@ asynStatus asynPortDriver::readOption(asynUser *pasynUser, const char *key, char
 
 extern "C" {static asynStatus writeOption(void *drvPvt, asynUser *pasynUser, const char *key, const char *value)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -3296,6 +3440,10 @@ asynStatus asynPortDriver::writeOption(asynUser *pasynUser, const char *key, con
 extern "C" {static asynStatus readEnum(void *drvPvt, asynUser *pasynUser, char *strings[], int values[], int severities[],
                                        size_t nElements, size_t *nIn)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -3323,6 +3471,10 @@ asynStatus asynPortDriver::readEnum(asynUser *pasynUser, char *strings[], int va
 
 extern "C" {static asynStatus writeEnum(void *drvPvt, asynUser *pasynUser, char *strings[], int values[], int severities[], size_t nElements)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -3386,6 +3538,10 @@ extern "C" {static asynStatus drvUserCreate(void *drvPvt, asynUser *pasynUser,
                                  const char *drvInfo,
                                  const char **pptypeName, size_t *psize)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -3429,6 +3585,10 @@ asynStatus asynPortDriver::drvUserCreate(asynUser *pasynUser,
 extern "C" {static asynStatus drvUserGetType(void *drvPvt, asynUser *pasynUser,
                                  const char **pptypeName, size_t *psize)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -3461,6 +3621,10 @@ asynStatus asynPortDriver::drvUserGetType(asynUser *pasynUser,
 
 extern "C" {static asynStatus drvUserDestroy(void *drvPvt, asynUser *pasynUser)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -3490,6 +3654,11 @@ asynStatus asynPortDriver::drvUserDestroy(asynUser *pasynUser)
 
 extern "C" {static void report(void *drvPvt, FILE *fp, int details)
 {
+    if (!drvPvt) {
+        fprintf(fp, "Port does not exist, nothing to report.\n");
+        return;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
 
     pPvt->lock();
@@ -3580,6 +3749,10 @@ asynStatus asynPortDriver::setTimeStamp(const epicsTimeStamp *pTimeStamp)
 
 extern "C" {static asynStatus connect(void *drvPvt, asynUser *pasynUser)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 
@@ -3610,6 +3783,10 @@ asynStatus asynPortDriver::connect(asynUser *pasynUser)
 
 extern "C" {static asynStatus disconnect(void *drvPvt, asynUser *pasynUser)
 {
+    if (!drvPvt) {
+        return asynDisabled;
+    }
+
     asynPortDriver *pPvt = (asynPortDriver *)drvPvt;
     asynStatus status;
 

--- a/asyn/asynPortDriver/asynPortDriver.cpp
+++ b/asyn/asynPortDriver/asynPortDriver.cpp
@@ -962,7 +962,7 @@ asynStatus asynPortDriver::unlock()
 /** Returns the asynStdInterfaces structure used by asynPortDriver. */
 asynStandardInterfaces* asynPortDriver::getAsynStdInterfaces()
 {
-    return &this->asynStdInterfaces;
+    return asynStdInterfaces;
 }
 
 /** Creates a parameter in the parameter library.
@@ -2920,7 +2920,7 @@ asynStatus asynPortDriver::doCallbacksInt8Array(epicsInt8 *value,
                                 size_t nElements, int reason, int addr)
 {
     return doCallbacksArray<epicsInt8, asynInt8ArrayInterrupt>(value, nElements, reason, addr,
-                                        this->asynStdInterfaces.int8ArrayInterruptPvt);
+                                        asynStdInterfaces->int8ArrayInterruptPvt);
 }
 
 
@@ -2991,7 +2991,7 @@ asynStatus asynPortDriver::doCallbacksInt16Array(epicsInt16 *value,
                                 size_t nElements, int reason, int addr)
 {
     return doCallbacksArray<epicsInt16, asynInt16ArrayInterrupt>(value, nElements, reason, addr,
-                                        this->asynStdInterfaces.int16ArrayInterruptPvt);
+                                        asynStdInterfaces->int16ArrayInterruptPvt);
 }
 
 
@@ -3062,7 +3062,7 @@ asynStatus asynPortDriver::doCallbacksInt32Array(epicsInt32 *value,
                                 size_t nElements, int reason, int addr)
 {
     return doCallbacksArray<epicsInt32, asynInt32ArrayInterrupt>(value, nElements, reason, addr,
-                                        this->asynStdInterfaces.int32ArrayInterruptPvt);
+                                        asynStdInterfaces->int32ArrayInterruptPvt);
 }
 
 
@@ -3133,7 +3133,7 @@ asynStatus asynPortDriver::doCallbacksInt64Array(epicsInt64 *value,
                                 size_t nElements, int reason, int addr)
 {
     return doCallbacksArray<epicsInt64, asynInt64ArrayInterrupt>(value, nElements, reason, addr,
-                                        this->asynStdInterfaces.int64ArrayInterruptPvt);
+                                        asynStdInterfaces->int64ArrayInterruptPvt);
 }
 
 
@@ -3204,7 +3204,7 @@ asynStatus asynPortDriver::doCallbacksFloat32Array(epicsFloat32 *value,
                                 size_t nElements, int reason, int addr)
 {
     return doCallbacksArray<epicsFloat32, asynFloat32ArrayInterrupt>(value, nElements, reason, addr,
-                                        this->asynStdInterfaces.float32ArrayInterruptPvt);
+                                        asynStdInterfaces->float32ArrayInterruptPvt);
 }
 
 
@@ -3275,7 +3275,7 @@ asynStatus asynPortDriver::doCallbacksFloat64Array(epicsFloat64 *value,
                                 size_t nElements, int reason, int addr)
 {
     return doCallbacksArray<epicsFloat64, asynFloat64ArrayInterrupt>(value, nElements, reason, addr,
-                                        this->asynStdInterfaces.float64ArrayInterruptPvt);
+                                        asynStdInterfaces->float64ArrayInterruptPvt);
 }
 
 /* asynGenericPointer interface methods */
@@ -3351,7 +3351,7 @@ asynStatus asynPortDriver::doCallbacksGenericPointer(void *genericPointer, int r
     getParamStatus(address, reason, &status);
     getParamAlarmStatus(address, reason, &alarmStatus);
     getParamAlarmSeverity(address, reason, &alarmSeverity);
-    pasynManager->interruptStart(this->asynStdInterfaces.genericPointerInterruptPvt, &pclientList);
+    pasynManager->interruptStart(asynStdInterfaces->genericPointerInterruptPvt, &pclientList);
     pnode = (interruptNode *)ellFirst(pclientList);
     while (pnode) {
         asynGenericPointerInterrupt *pInterrupt = (asynGenericPointerInterrupt *)pnode->drvPvt;
@@ -3372,7 +3372,7 @@ asynStatus asynPortDriver::doCallbacksGenericPointer(void *genericPointer, int r
         }
         pnode = (interruptNode *)ellNext(&pnode->node);
     }
-    pasynManager->interruptEnd(this->asynStdInterfaces.genericPointerInterruptPvt);
+    pasynManager->interruptEnd(asynStdInterfaces->genericPointerInterruptPvt);
     return asynSuccess;
 }
 
@@ -3513,7 +3513,7 @@ asynStatus asynPortDriver::doCallbacksEnum(char *strings[], int values[], int se
     interruptNode *pnode;
     int addr;
 
-    pasynManager->interruptStart(this->asynStdInterfaces.enumInterruptPvt, &pclientList);
+    pasynManager->interruptStart(asynStdInterfaces->enumInterruptPvt, &pclientList);
     pnode = (interruptNode *)ellFirst(pclientList);
     while (pnode) {
         asynEnumInterrupt *pInterrupt = (asynEnumInterrupt *)pnode->drvPvt;
@@ -3528,7 +3528,7 @@ asynStatus asynPortDriver::doCallbacksEnum(char *strings[], int values[], int se
         }
         pnode = (interruptNode *)ellNext(&pnode->node);
     }
-    pasynManager->interruptEnd(this->asynStdInterfaces.enumInterruptPvt);
+    pasynManager->interruptEnd(asynStdInterfaces->enumInterruptPvt);
     return asynSuccess;
 }
 
@@ -3677,15 +3677,13 @@ extern "C" {static void report(void *drvPvt, FILE *fp, int details)
   * call this base class function. */
 void asynPortDriver::report(FILE *fp, int details)
 {
-    asynStandardInterfaces *pInterfaces = &this->asynStdInterfaces;
-
     fprintf(fp, "Port: %s\n", this->portName);
     if (details >= 1) {
         char buff[256];
         epicsTimeStamp timeStamp; getTimeStamp(&timeStamp);
         epicsTimeToStrftime(buff, sizeof(buff), "%Y/%m/%d %H:%M:%S.%03f", &timeStamp);
         fprintf(fp, "  Timestamp: %s\n", buff);
-        if (asynStdInterfaces.octet.pinterface) {
+        if (asynStdInterfaces->octet.pinterface) {
             fprintf(fp, "  Input EOS[%d]: ", this->inputEosLenOctet);
             epicsStrPrintEscaped(fp, this->inputEosOctet, this->inputEosLenOctet);
             fprintf(fp, "\n");
@@ -3697,18 +3695,18 @@ void asynPortDriver::report(FILE *fp, int details)
     }
     if (details >= 3) {
         /* Report interrupt clients */
-        reportInterrupt<asynInt32Interrupt>         (fp, pInterfaces->int32InterruptPvt,        "int32");
-        reportInterrupt<asynInt64Interrupt>         (fp, pInterfaces->int64InterruptPvt,        "int64");
-        reportInterrupt<asynUInt32DigitalInterrupt> (fp, pInterfaces->uInt32DigitalInterruptPvt,"uint32");
-        reportInterrupt<asynFloat64Interrupt>       (fp, pInterfaces->float64InterruptPvt,      "float64");
-        reportInterrupt<asynOctetInterrupt>         (fp, pInterfaces->octetInterruptPvt,        "octet");
-        reportInterrupt<asynInt8ArrayInterrupt>     (fp, pInterfaces->int8ArrayInterruptPvt,    "int8Array");
-        reportInterrupt<asynInt16ArrayInterrupt>    (fp, pInterfaces->int16ArrayInterruptPvt,   "int16Array");
-        reportInterrupt<asynInt32ArrayInterrupt>    (fp, pInterfaces->int32ArrayInterruptPvt,   "int32Array");
-        reportInterrupt<asynFloat32ArrayInterrupt>  (fp, pInterfaces->float32ArrayInterruptPvt, "float32Array");
-        reportInterrupt<asynFloat64ArrayInterrupt>  (fp, pInterfaces->float64ArrayInterruptPvt, "float64Array");
-        reportInterrupt<asynGenericPointerInterrupt>(fp, pInterfaces->genericPointerInterruptPvt, "genericPointer");
-        reportInterrupt<asynEnumInterrupt>          (fp, pInterfaces->enumInterruptPvt,         "Enum");
+        reportInterrupt<asynInt32Interrupt>         (fp, asynStdInterfaces->int32InterruptPvt,        "int32");
+        reportInterrupt<asynInt64Interrupt>         (fp, asynStdInterfaces->int64InterruptPvt,        "int64");
+        reportInterrupt<asynUInt32DigitalInterrupt> (fp, asynStdInterfaces->uInt32DigitalInterruptPvt,"uint32");
+        reportInterrupt<asynFloat64Interrupt>       (fp, asynStdInterfaces->float64InterruptPvt,      "float64");
+        reportInterrupt<asynOctetInterrupt>         (fp, asynStdInterfaces->octetInterruptPvt,        "octet");
+        reportInterrupt<asynInt8ArrayInterrupt>     (fp, asynStdInterfaces->int8ArrayInterruptPvt,    "int8Array");
+        reportInterrupt<asynInt16ArrayInterrupt>    (fp, asynStdInterfaces->int16ArrayInterruptPvt,   "int16Array");
+        reportInterrupt<asynInt32ArrayInterrupt>    (fp, asynStdInterfaces->int32ArrayInterruptPvt,   "int32Array");
+        reportInterrupt<asynFloat32ArrayInterrupt>  (fp, asynStdInterfaces->float32ArrayInterruptPvt, "float32Array");
+        reportInterrupt<asynFloat64ArrayInterrupt>  (fp, asynStdInterfaces->float64ArrayInterruptPvt, "float64Array");
+        reportInterrupt<asynGenericPointerInterrupt>(fp, asynStdInterfaces->genericPointerInterruptPvt, "genericPointer");
+        reportInterrupt<asynEnumInterrupt>          (fp, asynStdInterfaces->enumInterruptPvt,         "Enum");
     }
 }
 
@@ -3988,14 +3986,16 @@ void asynPortDriver::initialize(const char *portNameIn, int maxAddrIn, int inter
 {
     asynStatus status;
     static const char *functionName = "asynPortDriver";
-    asynStandardInterfaces *pInterfaces;
     int addr;
 
     shutdownNeeded = asynFlags & ASYN_DESTRUCTIBLE;
 
-    /* Initialize some members to 0 */
-    pInterfaces = &this->asynStdInterfaces;
-    memset(pInterfaces, 0, sizeof(asynStdInterfaces));
+    /* Dynamically allocate standard interfaces, and never deallocate it. This
+     * causes a memory leak, but allows the interfaces to exist even after the
+     * driver has been destroyed. The interfaces will prevent the defunct driver
+     * to be accessed. */
+    asynStdInterfaces = new asynStandardInterfaces;
+    memset(asynStdInterfaces, 0, sizeof(*asynStdInterfaces));
 
     this->portName = epicsStrDup(portNameIn);
 
@@ -4049,39 +4049,39 @@ void asynPortDriver::initialize(const char *portNameIn, int maxAddrIn, int inter
         interruptMask, asynFlags, autoConnect, priority, stackSize);
 
      /* Set addresses of asyn interfaces */
-    if (interfaceMask & asynCommonMask)         pInterfaces->common.pinterface        = (void *)&ifaceCommon;
-    if (interfaceMask & asynDrvUserMask)        pInterfaces->drvUser.pinterface       = (void *)&ifaceDrvUser;
-    if (interfaceMask & asynInt32Mask)          pInterfaces->int32.pinterface         = (void *)&ifaceInt32;
-    if (interfaceMask & asynInt64Mask)          pInterfaces->int64.pinterface         = (void *)&ifaceInt64;
-    if (interfaceMask & asynUInt32DigitalMask)  pInterfaces->uInt32Digital.pinterface = (void *)&ifaceUInt32Digital;
-    if (interfaceMask & asynFloat64Mask)        pInterfaces->float64.pinterface       = (void *)&ifaceFloat64;
-    if (interfaceMask & asynOctetMask)          pInterfaces->octet.pinterface         = (void *)&ifaceOctet;
-    if (interfaceMask & asynInt8ArrayMask)      pInterfaces->int8Array.pinterface     = (void *)&ifaceInt8Array;
-    if (interfaceMask & asynInt16ArrayMask)     pInterfaces->int16Array.pinterface    = (void *)&ifaceInt16Array;
-    if (interfaceMask & asynInt32ArrayMask)     pInterfaces->int32Array.pinterface    = (void *)&ifaceInt32Array;
-    if (interfaceMask & asynInt64ArrayMask)     pInterfaces->int64Array.pinterface    = (void *)&ifaceInt64Array;
-    if (interfaceMask & asynFloat32ArrayMask)   pInterfaces->float32Array.pinterface  = (void *)&ifaceFloat32Array;
-    if (interfaceMask & asynFloat64ArrayMask)   pInterfaces->float64Array.pinterface  = (void *)&ifaceFloat64Array;
-    if (interfaceMask & asynGenericPointerMask) pInterfaces->genericPointer.pinterface= (void *)&ifaceGenericPointer;
-    if (interfaceMask & asynOptionMask)         pInterfaces->option.pinterface        = (void *)&ifaceOption;
-    if (interfaceMask & asynEnumMask)           pInterfaces->Enum.pinterface          = (void *)&ifaceEnum;
+    if (interfaceMask & asynCommonMask)         asynStdInterfaces->common.pinterface        = (void *)&ifaceCommon;
+    if (interfaceMask & asynDrvUserMask)        asynStdInterfaces->drvUser.pinterface       = (void *)&ifaceDrvUser;
+    if (interfaceMask & asynInt32Mask)          asynStdInterfaces->int32.pinterface         = (void *)&ifaceInt32;
+    if (interfaceMask & asynInt64Mask)          asynStdInterfaces->int64.pinterface         = (void *)&ifaceInt64;
+    if (interfaceMask & asynUInt32DigitalMask)  asynStdInterfaces->uInt32Digital.pinterface = (void *)&ifaceUInt32Digital;
+    if (interfaceMask & asynFloat64Mask)        asynStdInterfaces->float64.pinterface       = (void *)&ifaceFloat64;
+    if (interfaceMask & asynOctetMask)          asynStdInterfaces->octet.pinterface         = (void *)&ifaceOctet;
+    if (interfaceMask & asynInt8ArrayMask)      asynStdInterfaces->int8Array.pinterface     = (void *)&ifaceInt8Array;
+    if (interfaceMask & asynInt16ArrayMask)     asynStdInterfaces->int16Array.pinterface    = (void *)&ifaceInt16Array;
+    if (interfaceMask & asynInt32ArrayMask)     asynStdInterfaces->int32Array.pinterface    = (void *)&ifaceInt32Array;
+    if (interfaceMask & asynInt64ArrayMask)     asynStdInterfaces->int64Array.pinterface    = (void *)&ifaceInt64Array;
+    if (interfaceMask & asynFloat32ArrayMask)   asynStdInterfaces->float32Array.pinterface  = (void *)&ifaceFloat32Array;
+    if (interfaceMask & asynFloat64ArrayMask)   asynStdInterfaces->float64Array.pinterface  = (void *)&ifaceFloat64Array;
+    if (interfaceMask & asynGenericPointerMask) asynStdInterfaces->genericPointer.pinterface= (void *)&ifaceGenericPointer;
+    if (interfaceMask & asynOptionMask)         asynStdInterfaces->option.pinterface        = (void *)&ifaceOption;
+    if (interfaceMask & asynEnumMask)           asynStdInterfaces->Enum.pinterface          = (void *)&ifaceEnum;
 
     /* Define which interfaces can generate interrupts */
-    if (interruptMask & asynInt32Mask)          pInterfaces->int32CanInterrupt          = 1;
-    if (interruptMask & asynInt64Mask)          pInterfaces->int64CanInterrupt          = 1;
-    if (interruptMask & asynUInt32DigitalMask)  pInterfaces->uInt32DigitalCanInterrupt  = 1;
-    if (interruptMask & asynFloat64Mask)        pInterfaces->float64CanInterrupt        = 1;
-    if (interruptMask & asynOctetMask)          pInterfaces->octetCanInterrupt          = 1;
-    if (interruptMask & asynInt8ArrayMask)      pInterfaces->int8ArrayCanInterrupt      = 1;
-    if (interruptMask & asynInt16ArrayMask)     pInterfaces->int16ArrayCanInterrupt     = 1;
-    if (interruptMask & asynInt32ArrayMask)     pInterfaces->int32ArrayCanInterrupt     = 1;
-    if (interruptMask & asynInt64ArrayMask)     pInterfaces->int64ArrayCanInterrupt     = 1;
-    if (interruptMask & asynFloat32ArrayMask)   pInterfaces->float32ArrayCanInterrupt   = 1;
-    if (interruptMask & asynFloat64ArrayMask)   pInterfaces->float64ArrayCanInterrupt   = 1;
-    if (interruptMask & asynGenericPointerMask) pInterfaces->genericPointerCanInterrupt = 1;
-    if (interruptMask & asynEnumMask)           pInterfaces->enumCanInterrupt           = 1;
+    if (interruptMask & asynInt32Mask)          asynStdInterfaces->int32CanInterrupt          = 1;
+    if (interruptMask & asynInt64Mask)          asynStdInterfaces->int64CanInterrupt          = 1;
+    if (interruptMask & asynUInt32DigitalMask)  asynStdInterfaces->uInt32DigitalCanInterrupt  = 1;
+    if (interruptMask & asynFloat64Mask)        asynStdInterfaces->float64CanInterrupt        = 1;
+    if (interruptMask & asynOctetMask)          asynStdInterfaces->octetCanInterrupt          = 1;
+    if (interruptMask & asynInt8ArrayMask)      asynStdInterfaces->int8ArrayCanInterrupt      = 1;
+    if (interruptMask & asynInt16ArrayMask)     asynStdInterfaces->int16ArrayCanInterrupt     = 1;
+    if (interruptMask & asynInt32ArrayMask)     asynStdInterfaces->int32ArrayCanInterrupt     = 1;
+    if (interruptMask & asynInt64ArrayMask)     asynStdInterfaces->int64ArrayCanInterrupt     = 1;
+    if (interruptMask & asynFloat32ArrayMask)   asynStdInterfaces->float32ArrayCanInterrupt   = 1;
+    if (interruptMask & asynFloat64ArrayMask)   asynStdInterfaces->float64ArrayCanInterrupt   = 1;
+    if (interruptMask & asynGenericPointerMask) asynStdInterfaces->genericPointerCanInterrupt = 1;
+    if (interruptMask & asynEnumMask)           asynStdInterfaces->enumCanInterrupt           = 1;
 
-    status = pasynStandardInterfacesBase->initialize(portName, pInterfaces,
+    status = pasynStandardInterfacesBase->initialize(portName, asynStdInterfaces,
                                                      this->pasynUserSelf, this);
     if (status != asynSuccess) {
         std::string msg = std::string(driverName) + ":" + functionName +

--- a/asyn/asynPortDriver/asynPortDriver.cpp
+++ b/asyn/asynPortDriver/asynPortDriver.cpp
@@ -3963,8 +3963,6 @@ asynStatus asynPortDriver::createParams()
 
 asynStatus asynPortDriver::shutdown() {
     shutdownNeeded = false;
-    delete cbThread;
-    cbThread = NULL;
     return asynSuccess;
 }
 
@@ -3982,9 +3980,7 @@ asynPortDriver::~asynPortDriver()
                   driverName, portName);
     }
 
-    if (cbThread)
-        delete cbThread;
-
+    delete cbThread;
     epicsMutexDestroy(this->mutexId);
 
     for (int addr=0; addr<this->maxAddr; addr++) {

--- a/asyn/asynPortDriver/asynPortDriver.cpp
+++ b/asyn/asynPortDriver/asynPortDriver.cpp
@@ -4146,19 +4146,7 @@ void asynPortDriver::shutdown() {
     // and shutdown the port.
     if (needsShutdown()) {
         epics::atomic::set(shutdownNeeded, 0);
-        asynStatus status = pasynManager->lockPort(pasynUserSelf);
-        if(status != asynSuccess) {
-            if (status != asynDisabled) {
-                printf("%s\n", pasynUserSelf->errorMessage);
-            }
-            pasynManager->freeAsynUser(pasynUserSelf);
-            return;
-        }
-        status = pasynManager->shutdownPort(pasynUserSelf);
-        if(status != asynSuccess) {
-            printf("%s\n", pasynUserSelf->errorMessage);
-        }
-        status = pasynManager->unlockPort(pasynUserSelf);
+        asynStatus status = pasynManager->shutdownPort(pasynUserSelf);
         if(status != asynSuccess) {
             printf("%s\n", pasynUserSelf->errorMessage);
         }

--- a/asyn/asynPortDriver/asynPortDriver.cpp
+++ b/asyn/asynPortDriver/asynPortDriver.cpp
@@ -3973,7 +3973,7 @@ void asynPortDriver::shutdown() {
             pasynManager->freeAsynUser(pasynUserSelf);
             return;
         }
-        status = pasynManager->shutdown(pasynUserSelf);
+        status = pasynManager->shutdownPort(pasynUserSelf);
         if(status != asynSuccess) {
             printf("%s\n", pasynUserSelf->errorMessage);
         }

--- a/asyn/asynPortDriver/asynPortDriver.cpp
+++ b/asyn/asynPortDriver/asynPortDriver.cpp
@@ -3957,7 +3957,9 @@ void asynPortDriver::shutdown() {
         shutdownNeeded = false;
         asynStatus status = pasynManager->lockPort(pasynUserSelf);
         if(status != asynSuccess) {
-            printf("%s\n", pasynUserSelf->errorMessage);
+            if (status != asynDisabled) {
+                printf("%s\n", pasynUserSelf->errorMessage);
+            }
             pasynManager->freeAsynUser(pasynUserSelf);
             return;
         }

--- a/asyn/asynPortDriver/asynPortDriver.cpp
+++ b/asyn/asynPortDriver/asynPortDriver.cpp
@@ -962,7 +962,7 @@ asynStatus asynPortDriver::unlock()
 /** Returns the asynStdInterfaces structure used by asynPortDriver. */
 asynStandardInterfaces* asynPortDriver::getAsynStdInterfaces()
 {
-    return asynStdInterfaces;
+    return pasynStdInterfaces;
 }
 
 /** Creates a parameter in the parameter library.
@@ -2920,7 +2920,7 @@ asynStatus asynPortDriver::doCallbacksInt8Array(epicsInt8 *value,
                                 size_t nElements, int reason, int addr)
 {
     return doCallbacksArray<epicsInt8, asynInt8ArrayInterrupt>(value, nElements, reason, addr,
-                                        asynStdInterfaces->int8ArrayInterruptPvt);
+                                        pasynStdInterfaces->int8ArrayInterruptPvt);
 }
 
 
@@ -2991,7 +2991,7 @@ asynStatus asynPortDriver::doCallbacksInt16Array(epicsInt16 *value,
                                 size_t nElements, int reason, int addr)
 {
     return doCallbacksArray<epicsInt16, asynInt16ArrayInterrupt>(value, nElements, reason, addr,
-                                        asynStdInterfaces->int16ArrayInterruptPvt);
+                                        pasynStdInterfaces->int16ArrayInterruptPvt);
 }
 
 
@@ -3062,7 +3062,7 @@ asynStatus asynPortDriver::doCallbacksInt32Array(epicsInt32 *value,
                                 size_t nElements, int reason, int addr)
 {
     return doCallbacksArray<epicsInt32, asynInt32ArrayInterrupt>(value, nElements, reason, addr,
-                                        asynStdInterfaces->int32ArrayInterruptPvt);
+                                        pasynStdInterfaces->int32ArrayInterruptPvt);
 }
 
 
@@ -3133,7 +3133,7 @@ asynStatus asynPortDriver::doCallbacksInt64Array(epicsInt64 *value,
                                 size_t nElements, int reason, int addr)
 {
     return doCallbacksArray<epicsInt64, asynInt64ArrayInterrupt>(value, nElements, reason, addr,
-                                        asynStdInterfaces->int64ArrayInterruptPvt);
+                                        pasynStdInterfaces->int64ArrayInterruptPvt);
 }
 
 
@@ -3204,7 +3204,7 @@ asynStatus asynPortDriver::doCallbacksFloat32Array(epicsFloat32 *value,
                                 size_t nElements, int reason, int addr)
 {
     return doCallbacksArray<epicsFloat32, asynFloat32ArrayInterrupt>(value, nElements, reason, addr,
-                                        asynStdInterfaces->float32ArrayInterruptPvt);
+                                        pasynStdInterfaces->float32ArrayInterruptPvt);
 }
 
 
@@ -3275,7 +3275,7 @@ asynStatus asynPortDriver::doCallbacksFloat64Array(epicsFloat64 *value,
                                 size_t nElements, int reason, int addr)
 {
     return doCallbacksArray<epicsFloat64, asynFloat64ArrayInterrupt>(value, nElements, reason, addr,
-                                        asynStdInterfaces->float64ArrayInterruptPvt);
+                                        pasynStdInterfaces->float64ArrayInterruptPvt);
 }
 
 /* asynGenericPointer interface methods */
@@ -3351,7 +3351,7 @@ asynStatus asynPortDriver::doCallbacksGenericPointer(void *genericPointer, int r
     getParamStatus(address, reason, &status);
     getParamAlarmStatus(address, reason, &alarmStatus);
     getParamAlarmSeverity(address, reason, &alarmSeverity);
-    pasynManager->interruptStart(asynStdInterfaces->genericPointerInterruptPvt, &pclientList);
+    pasynManager->interruptStart(pasynStdInterfaces->genericPointerInterruptPvt, &pclientList);
     pnode = (interruptNode *)ellFirst(pclientList);
     while (pnode) {
         asynGenericPointerInterrupt *pInterrupt = (asynGenericPointerInterrupt *)pnode->drvPvt;
@@ -3372,7 +3372,7 @@ asynStatus asynPortDriver::doCallbacksGenericPointer(void *genericPointer, int r
         }
         pnode = (interruptNode *)ellNext(&pnode->node);
     }
-    pasynManager->interruptEnd(asynStdInterfaces->genericPointerInterruptPvt);
+    pasynManager->interruptEnd(pasynStdInterfaces->genericPointerInterruptPvt);
     return asynSuccess;
 }
 
@@ -3513,7 +3513,7 @@ asynStatus asynPortDriver::doCallbacksEnum(char *strings[], int values[], int se
     interruptNode *pnode;
     int addr;
 
-    pasynManager->interruptStart(asynStdInterfaces->enumInterruptPvt, &pclientList);
+    pasynManager->interruptStart(pasynStdInterfaces->enumInterruptPvt, &pclientList);
     pnode = (interruptNode *)ellFirst(pclientList);
     while (pnode) {
         asynEnumInterrupt *pInterrupt = (asynEnumInterrupt *)pnode->drvPvt;
@@ -3528,7 +3528,7 @@ asynStatus asynPortDriver::doCallbacksEnum(char *strings[], int values[], int se
         }
         pnode = (interruptNode *)ellNext(&pnode->node);
     }
-    pasynManager->interruptEnd(asynStdInterfaces->enumInterruptPvt);
+    pasynManager->interruptEnd(pasynStdInterfaces->enumInterruptPvt);
     return asynSuccess;
 }
 
@@ -3683,7 +3683,7 @@ void asynPortDriver::report(FILE *fp, int details)
         epicsTimeStamp timeStamp; getTimeStamp(&timeStamp);
         epicsTimeToStrftime(buff, sizeof(buff), "%Y/%m/%d %H:%M:%S.%03f", &timeStamp);
         fprintf(fp, "  Timestamp: %s\n", buff);
-        if (asynStdInterfaces->octet.pinterface) {
+        if (pasynStdInterfaces->octet.pinterface) {
             fprintf(fp, "  Input EOS[%d]: ", this->inputEosLenOctet);
             epicsStrPrintEscaped(fp, this->inputEosOctet, this->inputEosLenOctet);
             fprintf(fp, "\n");
@@ -3695,18 +3695,18 @@ void asynPortDriver::report(FILE *fp, int details)
     }
     if (details >= 3) {
         /* Report interrupt clients */
-        reportInterrupt<asynInt32Interrupt>         (fp, asynStdInterfaces->int32InterruptPvt,        "int32");
-        reportInterrupt<asynInt64Interrupt>         (fp, asynStdInterfaces->int64InterruptPvt,        "int64");
-        reportInterrupt<asynUInt32DigitalInterrupt> (fp, asynStdInterfaces->uInt32DigitalInterruptPvt,"uint32");
-        reportInterrupt<asynFloat64Interrupt>       (fp, asynStdInterfaces->float64InterruptPvt,      "float64");
-        reportInterrupt<asynOctetInterrupt>         (fp, asynStdInterfaces->octetInterruptPvt,        "octet");
-        reportInterrupt<asynInt8ArrayInterrupt>     (fp, asynStdInterfaces->int8ArrayInterruptPvt,    "int8Array");
-        reportInterrupt<asynInt16ArrayInterrupt>    (fp, asynStdInterfaces->int16ArrayInterruptPvt,   "int16Array");
-        reportInterrupt<asynInt32ArrayInterrupt>    (fp, asynStdInterfaces->int32ArrayInterruptPvt,   "int32Array");
-        reportInterrupt<asynFloat32ArrayInterrupt>  (fp, asynStdInterfaces->float32ArrayInterruptPvt, "float32Array");
-        reportInterrupt<asynFloat64ArrayInterrupt>  (fp, asynStdInterfaces->float64ArrayInterruptPvt, "float64Array");
-        reportInterrupt<asynGenericPointerInterrupt>(fp, asynStdInterfaces->genericPointerInterruptPvt, "genericPointer");
-        reportInterrupt<asynEnumInterrupt>          (fp, asynStdInterfaces->enumInterruptPvt,         "Enum");
+        reportInterrupt<asynInt32Interrupt>         (fp, pasynStdInterfaces->int32InterruptPvt,        "int32");
+        reportInterrupt<asynInt64Interrupt>         (fp, pasynStdInterfaces->int64InterruptPvt,        "int64");
+        reportInterrupt<asynUInt32DigitalInterrupt> (fp, pasynStdInterfaces->uInt32DigitalInterruptPvt,"uint32");
+        reportInterrupt<asynFloat64Interrupt>       (fp, pasynStdInterfaces->float64InterruptPvt,      "float64");
+        reportInterrupt<asynOctetInterrupt>         (fp, pasynStdInterfaces->octetInterruptPvt,        "octet");
+        reportInterrupt<asynInt8ArrayInterrupt>     (fp, pasynStdInterfaces->int8ArrayInterruptPvt,    "int8Array");
+        reportInterrupt<asynInt16ArrayInterrupt>    (fp, pasynStdInterfaces->int16ArrayInterruptPvt,   "int16Array");
+        reportInterrupt<asynInt32ArrayInterrupt>    (fp, pasynStdInterfaces->int32ArrayInterruptPvt,   "int32Array");
+        reportInterrupt<asynFloat32ArrayInterrupt>  (fp, pasynStdInterfaces->float32ArrayInterruptPvt, "float32Array");
+        reportInterrupt<asynFloat64ArrayInterrupt>  (fp, pasynStdInterfaces->float64ArrayInterruptPvt, "float64Array");
+        reportInterrupt<asynGenericPointerInterrupt>(fp, pasynStdInterfaces->genericPointerInterruptPvt, "genericPointer");
+        reportInterrupt<asynEnumInterrupt>          (fp, pasynStdInterfaces->enumInterruptPvt,         "Enum");
     }
 }
 
@@ -3912,7 +3912,9 @@ static asynDrvUser ifaceDrvUser = {
 asynPortDriver::asynPortDriver(asynParamSet* paramSet,
                                const char *portNameIn, int maxAddrIn, int interfaceMask, int interruptMask,
                                int asynFlags, int autoConnect, int priority, int stackSize):
-    paramSet(paramSet)
+    paramSet(paramSet),
+    pasynStdInterfaces(new asynStandardInterfaces),
+    asynStdInterfaces(*pasynStdInterfaces)
 {
     initialize(portNameIn, maxAddrIn, interfaceMask, interruptMask, asynFlags,
                autoConnect, priority, stackSize);
@@ -3940,7 +3942,9 @@ static asynDrvUser ifaceDrvUser = {
                will be assigned by asynManager.
   */
 asynPortDriver::asynPortDriver(const char *portNameIn, int maxAddrIn, int interfaceMask, int interruptMask,
-                               int asynFlags, int autoConnect, int priority, int stackSize)
+                               int asynFlags, int autoConnect, int priority, int stackSize):
+    pasynStdInterfaces(new asynStandardInterfaces),
+    asynStdInterfaces(*pasynStdInterfaces)
 {
     initialize(portNameIn, maxAddrIn, interfaceMask, interruptMask, asynFlags,
                autoConnect, priority, stackSize);
@@ -3955,7 +3959,9 @@ asynPortDriver::asynPortDriver(const char *portNameIn, int maxAddrIn, int interf
  * switch to using the constructor ASAP.
  */
 asynPortDriver::asynPortDriver(const char *portNameIn, int maxAddrIn, int paramTableSize, int interfaceMask, int interruptMask,
-                               int asynFlags, int autoConnect, int priority, int stackSize)
+                               int asynFlags, int autoConnect, int priority, int stackSize):
+    pasynStdInterfaces(new asynStandardInterfaces),
+    asynStdInterfaces(*pasynStdInterfaces)
 {
     initialize(portNameIn, maxAddrIn, interfaceMask, interruptMask, asynFlags,
                autoConnect, priority, stackSize);
@@ -3994,8 +4000,7 @@ void asynPortDriver::initialize(const char *portNameIn, int maxAddrIn, int inter
      * causes a memory leak, but allows the interfaces to exist even after the
      * driver has been destroyed. The interfaces will prevent the defunct driver
      * to be accessed. */
-    asynStdInterfaces = new asynStandardInterfaces;
-    memset(asynStdInterfaces, 0, sizeof(*asynStdInterfaces));
+    memset(pasynStdInterfaces, 0, sizeof(*pasynStdInterfaces));
 
     this->portName = epicsStrDup(portNameIn);
 
@@ -4049,39 +4054,39 @@ void asynPortDriver::initialize(const char *portNameIn, int maxAddrIn, int inter
         interruptMask, asynFlags, autoConnect, priority, stackSize);
 
      /* Set addresses of asyn interfaces */
-    if (interfaceMask & asynCommonMask)         asynStdInterfaces->common.pinterface        = (void *)&ifaceCommon;
-    if (interfaceMask & asynDrvUserMask)        asynStdInterfaces->drvUser.pinterface       = (void *)&ifaceDrvUser;
-    if (interfaceMask & asynInt32Mask)          asynStdInterfaces->int32.pinterface         = (void *)&ifaceInt32;
-    if (interfaceMask & asynInt64Mask)          asynStdInterfaces->int64.pinterface         = (void *)&ifaceInt64;
-    if (interfaceMask & asynUInt32DigitalMask)  asynStdInterfaces->uInt32Digital.pinterface = (void *)&ifaceUInt32Digital;
-    if (interfaceMask & asynFloat64Mask)        asynStdInterfaces->float64.pinterface       = (void *)&ifaceFloat64;
-    if (interfaceMask & asynOctetMask)          asynStdInterfaces->octet.pinterface         = (void *)&ifaceOctet;
-    if (interfaceMask & asynInt8ArrayMask)      asynStdInterfaces->int8Array.pinterface     = (void *)&ifaceInt8Array;
-    if (interfaceMask & asynInt16ArrayMask)     asynStdInterfaces->int16Array.pinterface    = (void *)&ifaceInt16Array;
-    if (interfaceMask & asynInt32ArrayMask)     asynStdInterfaces->int32Array.pinterface    = (void *)&ifaceInt32Array;
-    if (interfaceMask & asynInt64ArrayMask)     asynStdInterfaces->int64Array.pinterface    = (void *)&ifaceInt64Array;
-    if (interfaceMask & asynFloat32ArrayMask)   asynStdInterfaces->float32Array.pinterface  = (void *)&ifaceFloat32Array;
-    if (interfaceMask & asynFloat64ArrayMask)   asynStdInterfaces->float64Array.pinterface  = (void *)&ifaceFloat64Array;
-    if (interfaceMask & asynGenericPointerMask) asynStdInterfaces->genericPointer.pinterface= (void *)&ifaceGenericPointer;
-    if (interfaceMask & asynOptionMask)         asynStdInterfaces->option.pinterface        = (void *)&ifaceOption;
-    if (interfaceMask & asynEnumMask)           asynStdInterfaces->Enum.pinterface          = (void *)&ifaceEnum;
+    if (interfaceMask & asynCommonMask)         pasynStdInterfaces->common.pinterface        = (void *)&ifaceCommon;
+    if (interfaceMask & asynDrvUserMask)        pasynStdInterfaces->drvUser.pinterface       = (void *)&ifaceDrvUser;
+    if (interfaceMask & asynInt32Mask)          pasynStdInterfaces->int32.pinterface         = (void *)&ifaceInt32;
+    if (interfaceMask & asynInt64Mask)          pasynStdInterfaces->int64.pinterface         = (void *)&ifaceInt64;
+    if (interfaceMask & asynUInt32DigitalMask)  pasynStdInterfaces->uInt32Digital.pinterface = (void *)&ifaceUInt32Digital;
+    if (interfaceMask & asynFloat64Mask)        pasynStdInterfaces->float64.pinterface       = (void *)&ifaceFloat64;
+    if (interfaceMask & asynOctetMask)          pasynStdInterfaces->octet.pinterface         = (void *)&ifaceOctet;
+    if (interfaceMask & asynInt8ArrayMask)      pasynStdInterfaces->int8Array.pinterface     = (void *)&ifaceInt8Array;
+    if (interfaceMask & asynInt16ArrayMask)     pasynStdInterfaces->int16Array.pinterface    = (void *)&ifaceInt16Array;
+    if (interfaceMask & asynInt32ArrayMask)     pasynStdInterfaces->int32Array.pinterface    = (void *)&ifaceInt32Array;
+    if (interfaceMask & asynInt64ArrayMask)     pasynStdInterfaces->int64Array.pinterface    = (void *)&ifaceInt64Array;
+    if (interfaceMask & asynFloat32ArrayMask)   pasynStdInterfaces->float32Array.pinterface  = (void *)&ifaceFloat32Array;
+    if (interfaceMask & asynFloat64ArrayMask)   pasynStdInterfaces->float64Array.pinterface  = (void *)&ifaceFloat64Array;
+    if (interfaceMask & asynGenericPointerMask) pasynStdInterfaces->genericPointer.pinterface= (void *)&ifaceGenericPointer;
+    if (interfaceMask & asynOptionMask)         pasynStdInterfaces->option.pinterface        = (void *)&ifaceOption;
+    if (interfaceMask & asynEnumMask)           pasynStdInterfaces->Enum.pinterface          = (void *)&ifaceEnum;
 
     /* Define which interfaces can generate interrupts */
-    if (interruptMask & asynInt32Mask)          asynStdInterfaces->int32CanInterrupt          = 1;
-    if (interruptMask & asynInt64Mask)          asynStdInterfaces->int64CanInterrupt          = 1;
-    if (interruptMask & asynUInt32DigitalMask)  asynStdInterfaces->uInt32DigitalCanInterrupt  = 1;
-    if (interruptMask & asynFloat64Mask)        asynStdInterfaces->float64CanInterrupt        = 1;
-    if (interruptMask & asynOctetMask)          asynStdInterfaces->octetCanInterrupt          = 1;
-    if (interruptMask & asynInt8ArrayMask)      asynStdInterfaces->int8ArrayCanInterrupt      = 1;
-    if (interruptMask & asynInt16ArrayMask)     asynStdInterfaces->int16ArrayCanInterrupt     = 1;
-    if (interruptMask & asynInt32ArrayMask)     asynStdInterfaces->int32ArrayCanInterrupt     = 1;
-    if (interruptMask & asynInt64ArrayMask)     asynStdInterfaces->int64ArrayCanInterrupt     = 1;
-    if (interruptMask & asynFloat32ArrayMask)   asynStdInterfaces->float32ArrayCanInterrupt   = 1;
-    if (interruptMask & asynFloat64ArrayMask)   asynStdInterfaces->float64ArrayCanInterrupt   = 1;
-    if (interruptMask & asynGenericPointerMask) asynStdInterfaces->genericPointerCanInterrupt = 1;
-    if (interruptMask & asynEnumMask)           asynStdInterfaces->enumCanInterrupt           = 1;
+    if (interruptMask & asynInt32Mask)          pasynStdInterfaces->int32CanInterrupt          = 1;
+    if (interruptMask & asynInt64Mask)          pasynStdInterfaces->int64CanInterrupt          = 1;
+    if (interruptMask & asynUInt32DigitalMask)  pasynStdInterfaces->uInt32DigitalCanInterrupt  = 1;
+    if (interruptMask & asynFloat64Mask)        pasynStdInterfaces->float64CanInterrupt        = 1;
+    if (interruptMask & asynOctetMask)          pasynStdInterfaces->octetCanInterrupt          = 1;
+    if (interruptMask & asynInt8ArrayMask)      pasynStdInterfaces->int8ArrayCanInterrupt      = 1;
+    if (interruptMask & asynInt16ArrayMask)     pasynStdInterfaces->int16ArrayCanInterrupt     = 1;
+    if (interruptMask & asynInt32ArrayMask)     pasynStdInterfaces->int32ArrayCanInterrupt     = 1;
+    if (interruptMask & asynInt64ArrayMask)     pasynStdInterfaces->int64ArrayCanInterrupt     = 1;
+    if (interruptMask & asynFloat32ArrayMask)   pasynStdInterfaces->float32ArrayCanInterrupt   = 1;
+    if (interruptMask & asynFloat64ArrayMask)   pasynStdInterfaces->float64ArrayCanInterrupt   = 1;
+    if (interruptMask & asynGenericPointerMask) pasynStdInterfaces->genericPointerCanInterrupt = 1;
+    if (interruptMask & asynEnumMask)           pasynStdInterfaces->enumCanInterrupt           = 1;
 
-    status = pasynStandardInterfacesBase->initialize(portName, asynStdInterfaces,
+    status = pasynStandardInterfacesBase->initialize(portName, pasynStdInterfaces,
                                                      this->pasynUserSelf, this);
     if (status != asynSuccess) {
         std::string msg = std::string(driverName) + ":" + functionName +

--- a/asyn/asynPortDriver/asynPortDriver.cpp
+++ b/asyn/asynPortDriver/asynPortDriver.cpp
@@ -3971,7 +3971,7 @@ void asynPortDriver::exceptionHandler(asynUser *pasynUser, asynException excepti
                   "%s: port=%s Port is shutting down.\n",
                   driverName, pPvt->portName);
 
-        pPvt->shutdown();
+        pPvt->shutdownPortDriver();
         delete pPvt;
     }
 }
@@ -4138,7 +4138,7 @@ bool asynPortDriver::needsShutdown() {
  * This function is called with the driver *unlocked*. When overriding it, take
  * care to lock it as necessary.
  */
-void asynPortDriver::shutdown() {
+void asynPortDriver::shutdownPortDriver() {
     // There is a possibility that the destructor is running because we are
     // being directly deleted by user code, without going through asynManager.
     // Which would leave a "working" port with dangling references. So let's
@@ -4167,7 +4167,7 @@ asynPortDriver::~asynPortDriver()
         // At this point, the destructors of derived classes have already run,
         // so we can't do a proper shutdown anymore. But let's at least do our
         // own shutdown to mark the port as defunct.
-        shutdown();
+        shutdownPortDriver();
     }
     delete cbThread;
     epicsMutexDestroy(this->mutexId);

--- a/asyn/asynPortDriver/asynPortDriver.h
+++ b/asyn/asynPortDriver/asynPortDriver.h
@@ -204,13 +204,17 @@ public:
     void callbackTask();
 
 protected:
-    asynParamSet* paramSet;
+    virtual asynStatus shutdown();
     void initialize(const char *portNameIn, int maxAddrIn, int interfaceMask, int interruptMask, int asynFlags,
                     int autoConnect, int priority, int stackSize);
+
+    asynParamSet* paramSet;
     asynUser *pasynUserSelf;    /**< asynUser connected to ourselves for asynTrace */
     asynStandardInterfaces asynStdInterfaces;   /**< The asyn interfaces this driver implements */
 
 private:
+    static void exceptionHandler(asynUser *pasynUser, asynException exception);
+
     std::vector<paramList*> params;
     paramList *getParamList(int list);
     epicsMutexId mutexId;
@@ -219,6 +223,7 @@ private:
     char *outputEosOctet;
     int outputEosLenOctet;
     callbackThread *cbThread;
+    bool shutdownNeeded;
     template <typename epicsType, typename interruptType>
         asynStatus doCallbacksArray(epicsType *value, size_t nElements,
                                     int reason, int address, void *interruptPvt);

--- a/asyn/asynPortDriver/asynPortDriver.h
+++ b/asyn/asynPortDriver/asynPortDriver.h
@@ -197,7 +197,8 @@ public:
     virtual asynStatus setTimeStamp(const epicsTimeStamp *pTimeStamp);
     asynStandardInterfaces *getAsynStdInterfaces();
     virtual void reportParams(FILE *fp, int details);
-    virtual asynStatus shutdown();
+    virtual void shutdown();
+    bool needsShutdown();
 
     char *portName;         /**< The name of this asyn port */
 

--- a/asyn/asynPortDriver/asynPortDriver.h
+++ b/asyn/asynPortDriver/asynPortDriver.h
@@ -263,7 +263,7 @@ protected:
 
     asynParamSet* paramSet;
     asynUser *pasynUserSelf;    /**< asynUser connected to ourselves for asynTrace */
-    asynStandardInterfaces asynStdInterfaces;   /**< The asyn interfaces this driver implements */
+    asynStandardInterfaces *asynStdInterfaces;   /**< The asyn interfaces this driver implements */
 
 private:
     static void exceptionHandler(asynUser *pasynUser, asynException exception);

--- a/asyn/asynPortDriver/asynPortDriver.h
+++ b/asyn/asynPortDriver/asynPortDriver.h
@@ -197,6 +197,7 @@ public:
     virtual asynStatus setTimeStamp(const epicsTimeStamp *pTimeStamp);
     asynStandardInterfaces *getAsynStdInterfaces();
     virtual void reportParams(FILE *fp, int details);
+    virtual asynStatus shutdown();
 
     char *portName;         /**< The name of this asyn port */
 
@@ -204,7 +205,6 @@ public:
     void callbackTask();
 
 protected:
-    virtual asynStatus shutdown();
     void initialize(const char *portNameIn, int maxAddrIn, int interfaceMask, int interruptMask, int asynFlags,
                     int autoConnect, int priority, int stackSize);
 

--- a/asyn/asynPortDriver/asynPortDriver.h
+++ b/asyn/asynPortDriver/asynPortDriver.h
@@ -70,27 +70,27 @@ class callbackThread;
   *
   * 4. Your overriden `shutdown()` must call the base class implementation.
   *
+  * 5. When deleting a driver instance directly (e.g., in your test code),
+  *    always call `shutdown()` first.
+  *
   * To implement the above rules, you can use the following template:
   *
-  *     class myDriver : public baseDriver {
+  *     class myDriver : public asynPortDriver {
   *     public:
-  *         myDriver(const char *portName, ..., int asynFlags, ...) :
-  *               baseDriver(portName, ..., asynFlags, ...) {
-  *             // Your driver code; don't change the flags
+  *         myDriver(const char *portName, ...) :
+  *               asynPortDriver(portName, ..., ASYN_DESTRUCTIBLE, ...) {
+  *             // Your driver code.
   *         }
   *
   *         void shutdown() {
-  *             // Stop threads, use virtual functions
+  *             // Stop threads, you may use virtual functions.
+  *
+  *             // Don't forget to call the base class function.
   *             baseDriver::shutdown();
   *         }
   *
   *         ~myDriver() {
-  *             if (needsShutdown()) {
-  *                 // Not strictly needed, but allows your driver to be deleted
-  *                 // without calling shutdown() first, e.g. in tests.
-  *                 shutdown();
-  *             }
-  *             // Deallocate resources
+  *             // Deallocate resources, don't use virtual functions.
   *         }
   *     };
   */
@@ -276,7 +276,7 @@ private:
     char *outputEosOctet;
     int outputEosLenOctet;
     callbackThread *cbThread;
-    bool shutdownNeeded;
+    int shutdownNeeded;  // atomic!
     template <typename epicsType, typename interruptType>
         asynStatus doCallbacksArray(epicsType *value, size_t nElements,
                                     int reason, int address, void *interruptPvt);

--- a/asyn/asynPortDriver/asynPortDriver.h
+++ b/asyn/asynPortDriver/asynPortDriver.h
@@ -264,7 +264,8 @@ protected:
 
     asynParamSet* paramSet;
     asynUser *pasynUserSelf;    /**< asynUser connected to ourselves for asynTrace */
-    asynStandardInterfaces *asynStdInterfaces;   /**< The asyn interfaces this driver implements */
+    asynStandardInterfaces *pasynStdInterfaces;   /**< The asyn interfaces this driver implements */
+    asynStandardInterfaces &asynStdInterfaces;   /**< Back-compat alias */
 
 private:
     static void exceptionHandler(asynUser *pasynUser, asynException exception);

--- a/asyn/asynPortDriver/asynPortDriver.h
+++ b/asyn/asynPortDriver/asynPortDriver.h
@@ -53,7 +53,7 @@ class callbackThread;
   *
   * 1. Pass the `ASYN_DESTRUCTIBLE` flag to the constructor of `asynPortDriver`.
   *    This will ensure `asynManager` destroys your driver on process exit by
-  *    first calling `shutdown()`, then deleting.
+  *    first calling `shutdownPortDriver()`, then deleting.
   *
   * 2. To release resources that are private to your derived class, do so in the
   *    destructor. Remember, however, that no code from classes deriving from
@@ -63,15 +63,16 @@ class callbackThread;
   *    stopped.
   *
   * 3. To use functionality that requires an intact object, release resources by
-  *    overriding the `shutdown()` function. A possible example is stopping data
-  *    acquisition, which may involve functionality implemented in a derived
-  *    class. On process exit, `shutdown()` will be called before the
-  *    destructors are executed.
+  *    overriding the `shutdownPortDriver()` function. A possible example is
+  *    stopping data acquisition, which may involve functionality implemented in
+  *    a derived class. On process exit, `shutdownPortDriver()` will be called
+  *    before the destructors are executed.
   *
-  * 4. Your overriden `shutdown()` must call the base class implementation.
+  * 4. Your overriden `shutdownPortDriver()` must call the base class
+  *    implementation.
   *
   * 5. When deleting a driver instance directly (e.g., in your test code),
-  *    always call `shutdown()` first.
+  *    always call `shutdownPortDriver()` first.
   *
   * To implement the above rules, you can use the following template:
   *
@@ -82,11 +83,11 @@ class callbackThread;
   *             // Your driver code.
   *         }
   *
-  *         void shutdown() {
+  *         void shutdownPortDriver() {
   *             // Stop threads, you may use virtual functions.
   *
   *             // Don't forget to call the base class function.
-  *             baseDriver::shutdown();
+  *             baseDriver::shutdownPortDriver();
   *         }
   *
   *         ~myDriver() {
@@ -249,7 +250,7 @@ public:
     virtual asynStatus setTimeStamp(const epicsTimeStamp *pTimeStamp);
     asynStandardInterfaces *getAsynStdInterfaces();
     virtual void reportParams(FILE *fp, int details);
-    virtual void shutdown();
+    virtual void shutdownPortDriver();
     bool needsShutdown();
 
     char *portName;         /**< The name of this asyn port */

--- a/asyn/asynPortDriver/unittest/asynPortDriverTest.cpp
+++ b/asyn/asynPortDriver/unittest/asynPortDriverTest.cpp
@@ -214,7 +214,7 @@ MAIN(asynPortDriverTest)
             asynUser *pasynUser = pasynManager->createAsynUser(0, 0);
             pasynManager->connectDevice(pasynUser, tempPort->portName, 0);
             pasynManager->lockPort(pasynUser);
-            pasynManager->shutdown(pasynUser);
+            pasynManager->shutdownPort(pasynUser);
             pasynManager->unlockPort(pasynUser);
             pasynManager->freeAsynUser(pasynUser);
 

--- a/asyn/asynPortDriver/unittest/asynPortDriverTest.cpp
+++ b/asyn/asynPortDriver/unittest/asynPortDriverTest.cpp
@@ -221,7 +221,7 @@ MAIN(asynPortDriverTest)
             checkShutdown(portName.c_str());
         }
         {
-            testDiag("Testing a destructible port, early deletion");
+            testDiag("Testing a destructible port, early deletion, shows error message");
             asynPortDriver *tempPort = instantiateDriver("portD", true);
             testA(tempPort);
             std::string portName(tempPort->portName);

--- a/asyn/asynPortDriver/unittest/asynPortDriverTest.cpp
+++ b/asyn/asynPortDriver/unittest/asynPortDriverTest.cpp
@@ -214,9 +214,7 @@ MAIN(asynPortDriverTest)
             std::string portName(tempPort->portName);
             asynUser *pasynUser = pasynManager->createAsynUser(0, 0);
             pasynManager->connectDevice(pasynUser, tempPort->portName, 0);
-            pasynManager->lockPort(pasynUser);
             pasynManager->shutdownPort(pasynUser);
-            pasynManager->unlockPort(pasynUser);
             pasynManager->freeAsynUser(pasynUser);
 
             checkShutdown(portName.c_str());
@@ -254,9 +252,7 @@ MAIN(asynPortDriverTest)
             testOk1(pasynInt32SyncIO->connect(portName, 0, &intUser, "int32") == asynSuccess);
             testOk1(pasynInt32SyncIO->read(intUser, &val, 1.0) == asynSuccess);
 
-            pasynManager->lockPort(pasynUser);
             pasynManager->shutdownPort(pasynUser);
-            pasynManager->unlockPort(pasynUser);
             pasynManager->freeAsynUser(pasynUser);
 
             pcommon->report(pcommonIf->drvPvt, stdout, 0);

--- a/asyn/asynPortDriver/unittest/asynPortDriverTest.cpp
+++ b/asyn/asynPortDriver/unittest/asynPortDriverTest.cpp
@@ -260,8 +260,9 @@ MAIN(asynPortDriverTest)
             testOk1(pcommon->disconnect(pcommonIf->drvPvt, pasynUser) == asynDisabled);
             testOk1(pdrvUser->create(pdrvUserIf->drvPvt, pasynUser, "int32", 0, 0) == asynDisabled);
             testOk1(pdrvUser->destroy(pdrvUserIf->drvPvt, pasynUser) == asynDisabled);
-            testOk1(pasynInt32SyncIO->readOnce(portName, 0, &val, 1.0, "int32") == asynDisabled);
-            testOk1(pasynInt32SyncIO->read(intUser, &val, 1.0) == asynDisabled);
+            // Standard interfaces may return either asynDisabled or asynError
+            testOk1(pasynInt32SyncIO->readOnce(portName, 0, &val, 1.0, "int32") != asynSuccess);
+            testOk1(pasynInt32SyncIO->read(intUser, &val, 1.0) != asynSuccess);
         }
     } catch(std::exception& e) {
         testAbort("Unhandled C++ exception: %s", e.what());

--- a/asyn/miscellaneous/asynShellCommands.c
+++ b/asyn/miscellaneous/asynShellCommands.c
@@ -620,14 +620,7 @@ static const iocshArg asynSetTraceMaskArg1 = {"addr", iocshArgInt};
 static const iocshArg asynSetTraceMaskArg2 = {"mask", iocshArgString};
 static const iocshArg *const asynSetTraceMaskArgs[] = {
     &asynSetTraceMaskArg0,&asynSetTraceMaskArg1,&asynSetTraceMaskArg2};
-static const iocshFuncDef asynSetTraceMaskDef =
-    {"asynSetTraceMask", 3, asynSetTraceMaskArgs
-#ifdef IOCSHFUNCDEF_HAS_USAGE
-     ,
-#else
-    };
 static const char asynSetTraceMaskUsage[] =
-#endif
      "Set logging level bit mask, either as a number,"
      "  or since asyn R4-35 a combination of names.\n"
      "  mask bits\n"
@@ -640,13 +633,15 @@ static const char asynSetTraceMaskUsage[] =
      "\n"
      "  eg. the following are equivalent\n"
      "    asynSetTraceMask MYPORT -1 0x21\n"
-     "    asynSetTraceMask MYPORT -1 \"WARNING+ERROR\"\n"
+     "    asynSetTraceMask MYPORT -1 \"WARNING+ERROR\"\n";
+static const iocshFuncDef asynSetTraceMaskDef = {
+    "asynSetTraceMask",
+    3,
+    asynSetTraceMaskArgs
 #ifdef IOCSHFUNCDEF_HAS_USAGE
-    };
-#define asynSetTraceMaskUsage asynSetTraceMaskDef.usage
-#else
-    ;
+    , asynSetTraceMaskUsage
 #endif
+};
 ASYN_API int
  asynSetTraceMask(const char *portName,int addr,int mask)
 {
@@ -715,14 +710,7 @@ static const iocshArg asynSetTraceIOMaskArg1 = {"addr", iocshArgInt};
 static const iocshArg asynSetTraceIOMaskArg2 = {"mask", iocshArgString};
 static const iocshArg *const asynSetTraceIOMaskArgs[] = {
     &asynSetTraceIOMaskArg0,&asynSetTraceIOMaskArg1,&asynSetTraceIOMaskArg2};
-static const iocshFuncDef asynSetTraceIOMaskDef =
-    {"asynSetTraceIOMask", 3, asynSetTraceIOMaskArgs
-#ifdef IOCSHFUNCDEF_HAS_USAGE
-     ,
-#else
-    };
 static const char asynSetTraceIOMaskUsage[] =
-#endif
     "Set logging I/O print formatting bit mask, either as a number,\n"
     "  or since asyn R4-35 a combination of names.\n"
     "  mask bits\n"
@@ -732,13 +720,16 @@ static const char asynSetTraceIOMaskUsage[] =
     "\n"
     "  eg. the following are equivalent\n"
     "    asynSetTraceIOMask MYPORT -1 0x6\n"
-    "    asynSetTraceIOMask MYPORT -1 \"ESCAPE+HEX\"\n"
+    "    asynSetTraceIOMask MYPORT -1 \"ESCAPE+HEX\"\n";
+static const iocshFuncDef asynSetTraceIOMaskDef = {
+    "asynSetTraceIOMask",
+    3,
+    asynSetTraceIOMaskArgs
 #ifdef IOCSHFUNCDEF_HAS_USAGE
-    };
-#define asynSetTraceIOMaskUsage asynSetTraceIOMaskDef.usage
-#else
-    ;
+    , asynSetTraceIOMaskUsage
 #endif
+};
+
 ASYN_API int
  asynSetTraceIOMask(const char *portName,int addr,int mask)
 {
@@ -1317,22 +1308,17 @@ static void asynSetQueueLockPortTimeoutCall(const iocshArgBuf * args) {
 
 static const iocshArg asynShutdownPortArg0 = {"portName", iocshArgString};
 static const iocshArg *const asynShutdownPortArgs[] = {&asynShutdownPortArg0};
-static const iocshFuncDef asynShutdownPortDef =
-    {"asynShutdownPort", 1, asynShutdownPortArgs
-#ifdef IOCSHFUNCDEF_HAS_USAGE
-     ,
-#else
-    };
 static const char asynShutdownPortUsage[] =
-#endif
     "Permanently disables the port and destroys the port driver,\n"
-    "releasing its resources.\n"
+    "releasing its resources.\n";
+static const iocshFuncDef asynShutdownPortDef = {
+    "asynShutdownPort",
+    1,
+    asynShutdownPortArgs
 #ifdef IOCSHFUNCDEF_HAS_USAGE
-    };
-#define asynShutdownPortUsage asynShutdownPortDef.usage
-#else
-    ;
+    , asynShutdownPortUsage
 #endif
+};
 ASYN_API int
  asynShutdownPort(const char *portName)
 {

--- a/asyn/miscellaneous/asynShellCommands.c
+++ b/asyn/miscellaneous/asynShellCommands.c
@@ -1315,6 +1315,49 @@ static void asynSetQueueLockPortTimeoutCall(const iocshArgBuf * args) {
     asynSetQueueLockPortTimeout(portName,timeout);
 }
 
+static const iocshArg asynShutdownPortArg0 = {"portName", iocshArgString};
+static const iocshArg *const asynShutdownPortArgs[] = {&asynShutdownPortArg0};
+static const iocshFuncDef asynShutdownPortDef =
+    {"asynShutdownPort", 1, asynShutdownPortArgs
+#ifdef IOCSHFUNCDEF_HAS_USAGE
+     ,
+#else
+    };
+static const char asynShutdownPortUsage[] =
+#endif
+    "Permanently disables the port and destroys the port driver,\n"
+    "releasing its resources.\n"
+#ifdef IOCSHFUNCDEF_HAS_USAGE
+    };
+#define asynShutdownPortUsage asynShutdownPortDef.usage
+#else
+    ;
+#endif
+ASYN_API int
+ asynShutdownPort(const char *portName)
+{
+    asynUser *pasynUser;
+    asynStatus status;
+
+    pasynUser = pasynManager->createAsynUser(0, 0);
+    status = pasynManager->connectDevice(pasynUser, portName, 0);
+    if(status != asynSuccess) {
+        printf("%s\n", pasynUser->errorMessage);
+        pasynManager->freeAsynUser(pasynUser);
+        return -1;
+    }
+    status = pasynManager->shutdown(pasynUser);
+    if(status != asynSuccess) {
+        printf("%s\n", pasynUser->errorMessage);
+    }
+    pasynManager->freeAsynUser(pasynUser);
+    return 0;
+}
+static void asynShutdownPortCall(const iocshArgBuf * args) {
+    const char *portName = args[0].sval;
+    asynShutdownPort(portName);
+}
+
 static void asynRegister(void)
 {
     static int firstTime = 1;
@@ -1346,5 +1389,6 @@ static void asynRegister(void)
     iocshRegister(&asynRegisterTimeStampSourceDef, asynRegisterTimeStampSourceCall);
     iocshRegister(&asynUnregisterTimeStampSourceDef, asynUnregisterTimeStampSourceCall);
     iocshRegister(&asynSetMinTimerPeriodDef, asynSetMinTimerPeriodCall);
+    iocshRegister(&asynShutdownPortDef, asynShutdownPortCall);
 }
 epicsExportRegistrar(asynRegister);

--- a/asyn/miscellaneous/asynShellCommands.c
+++ b/asyn/miscellaneous/asynShellCommands.c
@@ -1346,7 +1346,17 @@ ASYN_API int
         pasynManager->freeAsynUser(pasynUser);
         return -1;
     }
+    status = pasynManager->lockPort(pasynUser);
+    if(status != asynSuccess) {
+        printf("%s\n", pasynUser->errorMessage);
+        pasynManager->freeAsynUser(pasynUser);
+        return -1;
+    }
     status = pasynManager->shutdown(pasynUser);
+    if(status != asynSuccess) {
+        printf("%s\n", pasynUser->errorMessage);
+    }
+    status = pasynManager->unlockPort(pasynUser);
     if(status != asynSuccess) {
         printf("%s\n", pasynUser->errorMessage);
     }

--- a/asyn/miscellaneous/asynShellCommands.c
+++ b/asyn/miscellaneous/asynShellCommands.c
@@ -1332,17 +1332,7 @@ ASYN_API int
         pasynManager->freeAsynUser(pasynUser);
         return -1;
     }
-    status = pasynManager->lockPort(pasynUser);
-    if(status != asynSuccess) {
-        printf("%s\n", pasynUser->errorMessage);
-        pasynManager->freeAsynUser(pasynUser);
-        return -1;
-    }
     status = pasynManager->shutdownPort(pasynUser);
-    if(status != asynSuccess) {
-        printf("%s\n", pasynUser->errorMessage);
-    }
-    status = pasynManager->unlockPort(pasynUser);
     if(status != asynSuccess) {
         printf("%s\n", pasynUser->errorMessage);
     }

--- a/asyn/miscellaneous/asynShellCommands.c
+++ b/asyn/miscellaneous/asynShellCommands.c
@@ -1338,7 +1338,7 @@ ASYN_API int
         pasynManager->freeAsynUser(pasynUser);
         return -1;
     }
-    status = pasynManager->shutdown(pasynUser);
+    status = pasynManager->shutdownPort(pasynUser);
     if(status != asynSuccess) {
         printf("%s\n", pasynUser->errorMessage);
     }

--- a/docs/source/asynDriver.rst
+++ b/docs/source/asynDriver.rst
@@ -425,7 +425,7 @@ Queuing services
 Basic Driver services
 .....................
   
-  Methods: registerPort, registerInterface, shutdown
+  Methods: registerPort, registerInterface, shutdownPort
 
   registerPort is called by a portDriver. registerInterface is called by a portDriver
   or an interposeInterface.
@@ -1111,7 +1111,7 @@ This is the main interface for communicating with asynDriver.
                                 asynInterface *pasynInterface,
                                 asynInterface **ppPrev);
       asynStatus (*enable)(asynUser *pasynUser,int yesNo);
-      asynStatus (*shutdown)(asynUser *pasynUser);
+      asynStatus (*shutdownPort)(asynUser *pasynUser);
       asynStatus (*autoConnect)(asynUser *pasynUser,int yesNo);
       asynStatus (*isConnected)(asynUser *pasynUser,int *yesNo);
       asynStatus (*isEnabled)(asynUser *pasynUser,int *yesNo);
@@ -1334,7 +1334,7 @@ This is the main interface for communicating with asynDriver.
   * - enable 
     - If enable is set yes, then queueRequests are not dequeued unless their queue timeout
       occurs.
-  * - shutdown
+  * - shutdownPort
     - The port is marked as defunct, preventing its use. It cannot be re-enabled.
       The underlying driver is notified and may be destroyed.
   * - autoConnect 

--- a/testAsynPortDriverApp/src/testAsynPortDriver.h
+++ b/testAsynPortDriverApp/src/testAsynPortDriver.h
@@ -46,6 +46,7 @@
 class testAsynPortDriver : public asynPortDriver {
 public:
     testAsynPortDriver(const char *portName, int maxArraySize);
+    ~testAsynPortDriver();
 
     /* These are the methods that we override from asynPortDriver */
     virtual asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);
@@ -81,6 +82,8 @@ protected:
 private:
     /* Our data */
     epicsEventId eventId_;
+    epicsThreadId threadId_;
+    bool exiting_;
     epicsFloat64 *pData_;
     epicsFloat64 *pTimeBase_;
     // Actual volts per division are these values divided by vertical gain


### PR DESCRIPTION
This PR extends `asynManager` to allow a port to be destructible, solving #172. It complements epics-base/epics-base#283.

# Goals

- Provide a function in `asynManager` and a corresponding iocsh command that shuts down a port.
- Shut down ports on IOC exit.
- The port cannot be re-enabled.
- The low-level driver is given a chance to release resources, or outright destroy itself.
- Access to the low-level driver is prevented.
- The `asynPortDriver` base class uses the new functionality.
- All of this is opt-in so that existing drivers continue to work as they always did.

# Port shutdown

There is a new function, `asynManager::shutdownPort()`, which
- disables the port, short-circuiting `asynManager::queueRequest()` and `asynManager::lockPort()`, thus preventing holders of `asynUser` dangling references from using them;
- nullifies all driver pointers that are reachable from the port, none of which should be reachable from user code thanks to the previous point;
- marks the port as defunct, which prevents re-enabling it;
- triggers a new exception, `asynExceptionShutdown`, which is to be handled by a conforming driver.

There is a new iocshell command that shuts down a port, useful mostly for testing.

This functionality is opt-in. A conforming driver declares that it is destructible by passing a new attribute, `ASYN_DESTRUCTIBLE`. In such a case, `asynManager` will register an `epicsAtExit` hook to call `shutdown()` on IOC exit. A conforming driver has to handle `asynExceptionShutdown` to perform cleanup, and may invalidate itself completely by calling `delete`.

# asynPortDriver and inheritance

`asynPortDriver` uses the new functionality by
- passing through `ASYN_DESTRUCTIBLE` if it is given to it via the `asynFlags` parameter;
- adding an exception handler that deletes the driver, relying on the destructor for cleanup;
- adding a new virtual function, `asynPortDriver::shutdownPortDriver()`, which allows things not possible in a destructor;
- calling `pasynManager::shutdownPort()` from its destructor (while preventing recursion) so that calling `delete` on the driver also disables the port.

Because this functionality is opt-in, there's a question of backwards compatibility in an inheritance tree, such as those in areaDetector. This can be solved by prescribing that a driver may only receive the `ASYN_DESTRUCTIBLE` flag and act upon it, but may not force it. This flag should come in via the iocshell command that instantiates a driver. This way, the driver will be destructible only if the most derived class is instantiated with this flag.

# Limitations

- It is not possible to release all memory because asyn was not designed in a way to allow that. A port and all the structures describing it will continue to exist indefinitely, as will those `asynUser` instances that the users don't destroy. But, as stated in #172, memory is not the resource that anyone is concerned about on IOC shutdown.
- Deleting a subclass of `asynPortDriver` directly, without calling `asynManager::shutdownPortDriver()`, can work, but only if the most derived class calls `asynPortDriver::shutdownPortDriver()` from its destructor. This is encouraged by the documentation but not enforced. It only affects unit tests that want to delete drivers, to my knowledge.

# TODO
- [x] documentation
- [x] tests