### PR TITLE
Add missing include of errlog.h

### DIFF
--- a/asyn/linuxGpib/drvLinuxGpib.c
+++ b/asyn/linuxGpib/drvLinuxGpib.c
@@ -29,6 +29,7 @@
 #include <iocsh.h>
 #include <callback.h>
 #include <cantProceed.h>
+#include <errlog.h>
 #include <epicsTime.h>
 #include <devLib.h>
 #include <taskwd.h>


### PR DESCRIPTION
The Linux GPIB driver was missing the include to define errlogPrintf(). 