### PR TITLE
Attempt to auto-detect TIRPC=YES

### DIFF
--- a/.ci-local/deps-latest.set
+++ b/.ci-local/deps-latest.set
@@ -1,8 +1,7 @@
-MODULES="sncseq sscan calc ipac"
+MODULES="sscan calc ipac"
 
 BASE_RECURSIVE=no
 
-SNCSEQ=master
 SSCAN=master
 CALC=master
 IPAC=master

--- a/.ci-local/deps1.set
+++ b/.ci-local/deps1.set
@@ -1,8 +1,7 @@
-MODULES="sncseq sscan calc ipac"
+MODULES="sscan calc ipac"
 
 BASE_RECURSIVE=no
 
-SNCSEQ=R2-2-8
 SSCAN=R2-11-3
 CALC=R3-7-3
 IPAC=2.15

--- a/.ci-local/deps2.set
+++ b/.ci-local/deps2.set
@@ -1,8 +1,7 @@
-MODULES="sncseq sscan calc ipac"
+MODULES="sscan calc ipac"
 
 BASE_RECURSIVE=no
 
-SNCSEQ=R2-2-8
 SSCAN=R2-11-5
 CALC=R3-7-4
 IPAC=2.16

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -108,9 +108,6 @@ jobs:
     - name: Prepare and compile EPICS dependencies
       run: python .ci/cue.py prepare
 
-    - name: TIRPC
-      run: echo TIRPC=YES > configure/CONFIG_SITE.Common.linux-x86_64
-
     - name: Build main module
       run: python .ci/cue.py build
 

--- a/configure/CONFIG_ASYN_MODULE
+++ b/configure/CONFIG_ASYN_MODULE
@@ -1,0 +1,14 @@
+
+ifdef T_A
+ifneq (,$(filter linux-%,$(T_A)))
+ifeq ($(EPICS_HOST_ARCH),$(T_A))
+
+ifneq (,$(firstword $(wildcard /usr/include/tirpc/rpc/rpc.h)))
+
+TIRPC ?= YES
+
+endif
+
+endif
+endif
+endif

--- a/configure/Makefile
+++ b/configure/Makefile
@@ -5,4 +5,6 @@ include $(TOP)/configure/CONFIG
 TARGETS = $(CONFIG_TARGETS)
 CONFIGS += $(subst ../,,$(wildcard $(CONFIG_INSTALLS)))
 
+CFG += CONFIG_ASYN_MODULE
+
 include $(TOP)/configure/RULES


### PR DESCRIPTION
Attempts to detect when `TIRPC=YES` is needed.  Currently only in the limited case where the host architecture is Linux.

Also, remove SNCSEQ from the CI builds as the BESSY site is still offline.