### PR TITLE
fix compilation of USBTMC for libusb < 1.0.22

### DIFF
--- a/asyn/drvAsynUSBTMC/drvAsynUSBTMC.c
+++ b/asyn/drvAsynUSBTMC/drvAsynUSBTMC.c
@@ -344,7 +344,11 @@ report(void *pvt, FILE *fp, int details)
     if (details >= 100) {
         int l = details % 100;
         fprintf(fp, "==== Set libusb debug level %d ====\n", l);
+#if LIBUSB_API_VERSION >= 0x01000106
         libusb_set_option(pdpvt->usb, LIBUSB_OPTION_LOG_LEVEL, l);
+#else
+        libusb_set_debug(pdpvt->usb, 1);
+#endif
     }
 }
 


### PR DESCRIPTION
Latest asyn w/ USBTMC does not compile on the ancient Centos7 that we use at ESS due to old availability of libusb 1.0.21.

As per https://libusb.sourceforge.io/api-1.0/group__libusb__lib.html#ga1c7862ed8e3f9402033d45307eefba0e.
