### PR TITLE
Fix mbboDirect asyn:READBACK

### DIFF
--- a/asyn/devEpics/devAsynUInt32Digital.c
+++ b/asyn/devEpics/devAsynUInt32Digital.c
@@ -1087,12 +1087,9 @@ static long processMbboDirect(mbboDirectRecord *pr)
 
             pr->rval = rval;
             if(pr->shft>0) rval >>= pr->shft;
+            pr->val = rval;
             for (i=0; i<NUM_BITS; i++, offset <<= 1, bit++ ) {
-                if(*bit) {
-                    pr->val |= offset;
-                } else {
-                    pr->val &= ~offset;
-                }
+                *bit = pr->val & offset;
             }
         }
     } else if(pr->pact == 0) {


### PR DESCRIPTION
This change makes mbboDirect behave the same as mbbiDirect: RVAL is copied to VAL (shifted, if neccessary), then each of the fields representing individual bits is set as well.

Fixes #207 