### PR TITLE
Fix issue with long timeouts in TCP connect()

### DIFF
--- a/asyn/asynDriver/asynDriver.h
+++ b/asyn/asynDriver/asynDriver.h
@@ -161,6 +161,7 @@ typedef struct asynManager {
     asynStatus (*isEnabled)(asynUser *pasynUser,int *yesNo);
     asynStatus (*isAutoConnect)(asynUser *pasynUser,int *yesNo);
     asynStatus (*setAutoConnectTimeout)(double timeout);
+    asynStatus (*getAutoConnectTimeout)(double *timeout);
     asynStatus (*waitConnect)(asynUser *pasynUser, double timeout);
     /*The following are methods for interrupts*/
     asynStatus (*registerInterruptSource)(const char *portName,

--- a/asyn/asynDriver/asynManager.c
+++ b/asyn/asynDriver/asynManager.c
@@ -313,6 +313,7 @@ static asynStatus isConnected(asynUser *pasynUser,int *yesNo);
 static asynStatus isEnabled(asynUser *pasynUser,int *yesNo);
 static asynStatus isAutoConnect(asynUser *pasynUser,int *yesNo);
 static asynStatus setAutoConnectTimeout(double timeout);
+static asynStatus getAutoConnectTimeout(double *timeout);
 static asynStatus waitConnect(asynUser *pasynUser, double timeout);
 static asynStatus registerInterruptSource(const char *portName,
     asynInterface *pasynInterface, void **pasynPvt);
@@ -370,6 +371,7 @@ static asynManager manager = {
     isEnabled,
     isAutoConnect,
     setAutoConnectTimeout,
+    getAutoConnectTimeout,
     waitConnect,
     registerInterruptSource,
     getInterruptPvt,
@@ -2218,6 +2220,15 @@ static asynStatus setAutoConnectTimeout(double timeout)
     if(!pasynBase) asynInit();
     epicsMutexMustLock(pasynBase->lock);
     pasynBase->autoConnectTimeout = timeout;
+    epicsMutexUnlock(pasynBase->lock);
+    return asynSuccess;
+}
+
+static asynStatus getAutoConnectTimeout(double *timeout)
+{
+    if(!pasynBase) asynInit();
+    epicsMutexMustLock(pasynBase->lock);
+    *timeout = pasynBase->autoConnectTimeout;
     epicsMutexUnlock(pasynBase->lock);
     return asynSuccess;
 }

--- a/asyn/drvAsynSerial/drvAsynIPPort.c
+++ b/asyn/drvAsynSerial/drvAsynIPPort.c
@@ -511,7 +511,22 @@ connectIt(void *drvPvt, asynUser *pasynUser)
          * problem is just that the device has DHCP'd itself an new number.
          */
         if (tty->socketType != SOCK_DGRAM) {
+            double connectTimeout;
+            struct timeval saveTV, connectTV;
+            socklen_t svlen = sizeof saveTV;
+            pasynManager->getAutoConnectTimeout(&connectTimeout);
+            connectTV.tv_sec = (time_t)connectTimeout;
+            connectTV.tv_usec = (suseconds_t)((connectTimeout - connectTV.tv_sec)*1000000);
+            asynPrint(pasynUser, ASYN_TRACE_ERROR, "Calling setsockopt SO_SNDTIMEO tv_sec=%d tv_usec=%d\n", connectTV.tv_sec, connectTV.tv_usec);
+            if (getsockopt (fd, SOL_SOCKET, SO_SNDTIMEO, (char *)&saveTV, &svlen) < 0) {
+                asynPrint(pasynUser, ASYN_TRACE_ERROR, "connectIt, error calling getsockopt for SO_RECVTIMEO: %s\n", strerror(SOCKERRNO));
+            }
+            if (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, (char *)&connectTV, sizeof connectTV) < 0) {
+                 asynPrint(pasynUser, ASYN_TRACE_ERROR, "connectIt, error calling setsockopt for SO_RECVTIMEO: %s\n", strerror(SOCKERRNO));
+            }
+            asynPrint(pasynUser, ASYN_TRACE_ERROR, "connectIt, calling connect()\n");
             if (connect(fd, &tty->farAddr.oa.sa, (int)tty->farAddrSize) < 0) {
+                asynPrint(pasynUser, ASYN_TRACE_ERROR, "connectIt, connect returned error: %s\n", strerror(SOCKERRNO));
                 epicsSnprintf(pasynUser->errorMessage,pasynUser->errorMessageSize,
                               "Can't connect to %s: %s",
                               tty->IPDeviceName, strerror(SOCKERRNO));
@@ -519,6 +534,9 @@ connectIt(void *drvPvt, asynUser *pasynUser)
                 if (tty->flags & FLAG_DONE_LOOKUP)
                     tty->flags |=  FLAG_NEED_LOOKUP;
                 return asynError;
+            }
+            if (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, (char *)&saveTV, sizeof saveTV) < 0) {
+                asynPrint(pasynUser, ASYN_TRACE_ERROR, "connectIt, error calling setsockopt for SO_RECVTIMEO: %s\n", strerror(SOCKERRNO));
             }
         }
     }

--- a/asyn/drvAsynSerial/drvAsynIPPort.c
+++ b/asyn/drvAsynSerial/drvAsynIPPort.c
@@ -543,8 +543,8 @@ connectIt(void *drvPvt, asynUser *pasynUser)
 #ifdef USE_CONNECTTIMEOUT
             if (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, (char *)&saveTV, sizeof saveTV) < 0) {
                 asynPrint(pasynUser, ASYN_TRACE_ERROR, "connectIt, error calling setsockopt for SO_SNDTIMEO: %s\n", strerror(SOCKERRNO));
-#endif
             }
+#endif
         }
     }
     i = 1;

--- a/asyn/drvAsynSerial/drvAsynIPPort.c
+++ b/asyn/drvAsynSerial/drvAsynIPPort.c
@@ -86,8 +86,9 @@
 #endif
 
 /* Linux after version 2.3.31 (2001) supports SO_SNDTIMEO for connect() calls. It uses a timeval argument.
- * Windows supports SO_SNDTIMEO but it takes a DWORD argument and does not appear to apply to connect() calls. */
-#if defined(linux)
+ * Windows supports SO_SNDTIMEO but it takes a DWORD argument and does not appear to apply to connect() calls. 
+ * Darwin supports SO_SNDTIMEO but the documentation is not clear whether it applies to connect() calls. */
+#if defined(linux) || defined(darwin)
 # define USE_CONNECTTIMEOUT
 #endif
 

--- a/asyn/drvAsynSerial/drvAsynIPPort.c
+++ b/asyn/drvAsynSerial/drvAsynIPPort.c
@@ -515,18 +515,15 @@ connectIt(void *drvPvt, asynUser *pasynUser)
             struct timeval saveTV, connectTV;
             socklen_t svlen = sizeof saveTV;
             pasynManager->getAutoConnectTimeout(&connectTimeout);
-            connectTV.tv_sec = (time_t)connectTimeout;
-            connectTV.tv_usec = (suseconds_t)((connectTimeout - connectTV.tv_sec)*1000000);
-            asynPrint(pasynUser, ASYN_TRACE_ERROR, "Calling setsockopt SO_SNDTIMEO tv_sec=%d tv_usec=%d\n", connectTV.tv_sec, connectTV.tv_usec);
+            connectTV.tv_sec = (long)connectTimeout;
+            connectTV.tv_usec = (long)((connectTimeout - connectTV.tv_sec)*1000000);
             if (getsockopt (fd, SOL_SOCKET, SO_SNDTIMEO, (char *)&saveTV, &svlen) < 0) {
                 asynPrint(pasynUser, ASYN_TRACE_ERROR, "connectIt, error calling getsockopt for SO_RECVTIMEO: %s\n", strerror(SOCKERRNO));
             }
             if (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, (char *)&connectTV, sizeof connectTV) < 0) {
                  asynPrint(pasynUser, ASYN_TRACE_ERROR, "connectIt, error calling setsockopt for SO_RECVTIMEO: %s\n", strerror(SOCKERRNO));
             }
-            asynPrint(pasynUser, ASYN_TRACE_ERROR, "connectIt, calling connect()\n");
             if (connect(fd, &tty->farAddr.oa.sa, (int)tty->farAddrSize) < 0) {
-                asynPrint(pasynUser, ASYN_TRACE_ERROR, "connectIt, connect returned error: %s\n", strerror(SOCKERRNO));
                 epicsSnprintf(pasynUser->errorMessage,pasynUser->errorMessageSize,
                               "Can't connect to %s: %s",
                               tty->IPDeviceName, strerror(SOCKERRNO));


### PR DESCRIPTION
This PR sets the sockopt SO_SNDTIMEO to the time set by  pasynManager->setAutoConnectTimeout() during the call to connect().  This allows must faster timeouts than the system default.  It has been tested on Linux and Windows.
