### PR TITLE
Queue connect timer on autoconnect enable

### DIFF
--- a/asyn/asynDriver/asynManager.c
+++ b/asyn/asynDriver/asynManager.c
@@ -2319,6 +2319,9 @@ static asynStatus autoConnectAsyn(asynUser *pasynUser,int yesNo)
         return asynError;
     }
     pdpCommon->autoConnect = (yesNo ? 1 : 0);
+    if(!pdpCommon->connected && pdpCommon->autoConnect) {
+        epicsTimerStartDelay(pport->connectTimer,.01);
+    }
     exceptionOccurred(pasynUser,asynExceptionAutoConnect);
     return asynSuccess;
 }


### PR DESCRIPTION
Hi @MarkRivers we have an issue with late enabling of autoconnect and I was wondering if this was a valid fix.

 We setup some ports with `drvAsynIPPortConfigure` and autoconnect disabled and then later in SNL we use  `pasynManager->autoConnect`  (like inside the `asynAutoConnect` epics cmd) to enable autoconnect . It seems with this approach that we get an initial connection attempt, but if this fails no further attempts are queued.

Is the correct fix to start a connection timer in the  `autoConnectAsyn` function or is another approach better?

Thanks,

Freddie