### PR TITLE
Allow to specify the path to the FTDI library

### DIFF
--- a/asyn/Makefile
+++ b/asyn/Makefile
@@ -263,11 +263,25 @@ ifeq ($(DRV_FTDI),YES)
   asyn_SYS_LIBS += usb-1.0
   INC += drvAsynFTDIPort.h
   ifeq ($(DRV_FTDI_USE_LIBFTDI1),YES)
-    asyn_SYS_LIBS += ftdi1
-    USR_CXXFLAGS += -DHAVE_LIBFTDI1
+     USR_CXXFLAGS += -DHAVE_LIBFTDI1
+     ifeq ($(FTDI_LIB),)
+       asyn_SYS_LIBS += ftdi1
+     else
+       asyn_LIBS += ftdi1
+       ftdi1_DIR = $(FTDI_LIB)
+     endif
   else
-    asyn_SYS_LIBS += ftdi
+     ifeq ($(FTDI_LIB),)
+       asyn_SYS_LIBS += ftdi
+     else
+       asyn_LIBS += ftdi
+       ftdi_DIR = $(FTDI_LIB)
+     endif
   endif
+  ifdef FTDI_INCLUDE
+    USR_INCLUDES += $(addprefix -I, $(FTDI_INCLUDE))
+  endif
+
   DBD += drvAsynFTDIPort.dbd
 endif
 

--- a/asyn/Makefile
+++ b/asyn/Makefile
@@ -263,21 +263,22 @@ ifeq ($(DRV_FTDI),YES)
   asyn_SYS_LIBS += usb-1.0
   INC += drvAsynFTDIPort.h
   ifeq ($(DRV_FTDI_USE_LIBFTDI1),YES)
-     USR_CXXFLAGS += -DHAVE_LIBFTDI1
-     ifeq ($(FTDI_LIB),)
-       asyn_SYS_LIBS += ftdi1
-     else
-       asyn_LIBS += ftdi1
-       ftdi1_DIR = $(FTDI_LIB)
-     endif
+    USR_CXXFLAGS += -DHAVE_LIBFTDI1
+    ifeq ($(FTDI_LIB),)
+      asyn_SYS_LIBS += ftdi1
+    else
+      asyn_LIBS += ftdi1
+      ftdi1_DIR = $(FTDI_LIB)
+    endif
   else
-     ifeq ($(FTDI_LIB),)
-       asyn_SYS_LIBS += ftdi
-     else
-       asyn_LIBS += ftdi
-       ftdi_DIR = $(FTDI_LIB)
-     endif
+    ifeq ($(FTDI_LIB),)
+      asyn_SYS_LIBS += ftdi
+    else
+      asyn_LIBS += ftdi
+      ftdi_DIR = $(FTDI_LIB)
+    endif
   endif
+
   ifdef FTDI_INCLUDE
     USR_INCLUDES += $(addprefix -I, $(FTDI_INCLUDE))
   endif


### PR DESCRIPTION
This is useful if libftdi is not installed in the system library path