### PR TITLE
Fix compilatition faliure for asynStatus in clang 17

### DIFF
--- a/asyn/asynDriver/asynDriver.h
+++ b/asyn/asynDriver/asynDriver.h
@@ -46,7 +46,19 @@ extern "C" {
 
 
 typedef enum {
-    asynSuccess,asynTimeout,asynOverflow,asynError,asynDisconnected,asynDisabled
+    asynSuccess,
+    asynTimeout,
+    asynOverflow,
+    asynError,
+    asynDisconnected,
+    asynDisabled,
+    /* Values used for the param interface */
+    asynParamAlreadyExists,
+    asynParamNotFound,
+    asynParamWrongType,
+    asynParamBadIndex,
+    asynParamUndefined,
+    asynParamInvalidList
 }asynStatus;
 
 typedef enum {

--- a/asyn/asynDriver/asynManager.c
+++ b/asyn/asynDriver/asynManager.c
@@ -3211,6 +3211,12 @@ static const char *strStatus(asynStatus status)
     case asynError:         return "asynError";
     case asynDisconnected:  return "asynDisconnected";
     case asynDisabled:      return "asynDisabled";
+    case asynParamAlreadyExists: return "asynParamAlreadyExists";
+    case asynParamNotFound: return "asynParamNotFound";
+    case asynParamWrongType: return "asynParamWrongType";
+    case asynParamBadIndex: return "asynParamBadIndex";
+    case asynParamUndefined: return "asynParamUndefined";
+    case asynParamInvalidList: return "asynParamInvalidList";
     }
 
     return "asyn????";

--- a/asyn/asynPortDriver/paramErrors.h
+++ b/asyn/asynPortDriver/paramErrors.h
@@ -10,13 +10,4 @@
 
 #include <asynDriver.h>
 
-/* Extend asynManager error list.  We should have a way of knowing what the last error in asyn is */
-#define asynParamAlreadyExists (asynStatus)(asynDisabled + 1)
-#define asynParamNotFound      (asynStatus)(asynDisabled + 2)
-#define asynParamWrongType     (asynStatus)(asynDisabled + 3)
-#define asynParamBadIndex      (asynStatus)(asynDisabled + 4)
-#define asynParamUndefined     (asynStatus)(asynDisabled + 5)
-#define asynParamInvalidList   (asynStatus)(asynDisabled + 6)
-
-
 #endif /* ASYNPORTDRIVERERRORSTATES_H_ */


### PR DESCRIPTION
After installing a new clang under MacOS:
```
c++ --version
Apple clang version 17.0.0 (clang-1700.6.3.2)
Target: x86_64-apple-darwin24.6.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin ----------------
```
the compilation of a motor driver failed:
```
c++ -DUNIX -Ddarwin -O3 -g -Wall -arch x86_64 -fno-common -fPIC -I. -I../O.Common -I. -I. -I.. -I.../epics/modules/motor/include/compiler/clang -I.../epics/modules/motor/include/os/Darwin -I.../epics/modules/motor/include -I.../epics/modules/motor/include -I.../epics/base/../modules/asyn/include -I.../epics/base/include/compiler/clang -I.../epics/base/include/os/Darwin -I.../epics/base/include -c ../smarActMCS2MotorDriver.cpp ../smarActMCS2MotorDriver.cpp:147:10: error: integer value 8 is outside the valid range of
      values [0, 7] for the enumeration type 'asynStatus' [-Wenum-constexpr-conversion]
  147 |     case asynParamWrongType:
      |          ^
.../epics/base/../modules/asyn/include/paramErrors.h:16:32: note:
      expanded from macro 'asynParamWrongType'
   16 | #define asynParamWrongType     (asynStatus)(asynDisabled + 3)
      |                                ^
../smarActMCS2MotorDriver.cpp:149:10: error: integer value 9 is outside the valid range of
      values [0, 7] for the enumeration type 'asynStatus' [-Wenum-constexpr-conversion]
  149 |     case asynParamBadIndex:
      |          ^
.../epics/base/../modules/asyn/include/paramErrors.h:17:32: note:
      expanded from macro 'asynParamBadIndex'
   17 | #define asynParamBadIndex      (asynStatus)(asynDisabled + 4)
      |                                ^
../smarActMCS2MotorDriver.cpp:151:10: error: integer value 10 is outside the valid range of
      values [0, 7] for the enumeration type 'asynStatus' [-Wenum-constexpr-conversion]
  151 |     case asynParamUndefined:
      |          ^
.../epics/base/../modules/asyn/include/paramErrors.h:18:32: note:
      expanded from macro 'asynParamUndefined'
   18 | #define asynParamUndefined     (asynStatus)(asynDisabled + 5)
      |                                ^
3 errors generated.
----------------
```
Solution:
Define all possible values for asynStatus in asynDriver.h

Changes to be committed:
    modified:   asyn/asynDriver/asynDriver.h
    modified:   asyn/asynDriver/asynManager.c
    modified:   asyn/asynPortDriver/paramErrors.h