### PR TITLE
fix struct dbEntry undefined error on base 3.15

### DIFF
--- a/asyn/devEpics/devEpicsPvt.c
+++ b/asyn/devEpics/devEpicsPvt.c
@@ -16,7 +16,7 @@
 #if EPICS_VERSION_INT < VERSION_INT(3, 16, 1, 0)
 static
 void dbInitEntryFromRecord(struct dbCommon *prec,
-                           struct dbEntry *pdbentry)
+                           DBENTRY *pdbentry)
 {
     long status;
     dbInitEntry(pdbbase, pdbentry);


### PR DESCRIPTION
This PR fix #223 

`struct dbEntry` is not defined until epics 7. Inside ci env, this generates warning, but on my raspi 5 (debian 13), it won't compile.

```shell
/usr/bin/gcc  -D_GNU_SOURCE -D_DEFAULT_SOURCE        -DUSE_TYPED_RSET -DUSE_TYPED_DSET -DUSE_TYPED_DRVET -DBUILDING_asyn_API   -DUNIX  -Dlinux     -O3   -Wall    -DUSE_TYPED_RSET -DUSE_TYPED_DSET -DUSE_TYPED_DRVET -DHAVE_LSREC       -fPIC -I. -I../O.Common -I. -I. -I../../asyn/drvAsynSerial/os/Linux -I../../asyn/drvAsynSerial/os/default -I.. -I../../asyn/asynDriver -I../../asyn/asynGpib -I../../asyn/drvAsynSerial -I../../asyn/interfaces -I../../asyn/miscellaneous -I../../asyn/asynPortDriver/exceptions -I../../asyn/asynPortDriver -I../../asyn/asynPortClient -I../../asyn/devEpics -I../../asyn/asynRecord -I../../asyn/vxi11 -I../../asyn/drvPrologixGPIB -I../../asyn/ni1014 -I../../asyn/devGpib -I../../include/compiler/gcc -I../../include/os/Linux -I../../include    -I/home/pi/epics/R3.15.9/base/include/compiler/gcc -I/home/pi/epics/R3.15.9/base/include/os/Linux -I/home/pi/epics/R3.15.9/base/include        -c ../../asyn/devEpics/devEpicsPvt.c
../../asyn/devEpics/devEpicsPvt.c:19:35: warning: ‘struct dbEntry’ declared inside parameter list will not be visible outside of this definition or declaration
   19 |                            struct dbEntry *pdbentry)
      |                                   ^~~~~~~
../../asyn/devEpics/devEpicsPvt.c: In function ‘dbInitEntryFromRecord’:
../../asyn/devEpics/devEpicsPvt.c:22:26: error: passing argument 2 of ‘dbInitEntry’ from incompatible pointer type [-Wincompatible-pointer-types]
   22 |     dbInitEntry(pdbbase, pdbentry);
      |                          ^~~~~~~~
      |                          |
      |                          struct dbEntry *
In file included from ../../asyn/devEpics/devEpicsPvt.c:10:
/home/pi/epics/R3.15.9/base/include/dbStaticLib.h:69:14: note: expected ‘DBENTRY *’ but argument is of type ‘struct dbEntry *’
   69 |     DBENTRY *pdbentry);
      |     ~~~~~~~~~^~~~~~~~
../../asyn/devEpics/devEpicsPvt.c:23:27: error: passing argument 1 of ‘dbFindRecord’ from incompatible pointer type [-Wincompatible-pointer-types]
   23 |     status = dbFindRecord(pdbentry, prec->name);
      |                           ^~~~~~~~
      |                           |
      |                           struct dbEntry *
/home/pi/epics/R3.15.9/base/include/dbStaticLib.h:141:43: note: expected ‘DBENTRY *’ but argument is of type ‘struct dbEntry *’
  141 | epicsShareFunc long dbFindRecord(DBENTRY *pdbentry,
      |                                  ~~~~~~~~~^~~~~~~~
../../asyn/devEpics/devEpicsPvt.c: In function ‘asynDbGetInfo’:
../../asyn/devEpics/devEpicsPvt.c:32:33: error: passing argument 2 of ‘dbInitEntryFromRecord’ from incompatible pointer type [-Wincompatible-pointer-types]
   32 |     dbInitEntryFromRecord(prec, &ent);
      |                                 ^~~~
      |                                 |
      |                                 DBENTRY *
../../asyn/devEpics/devEpicsPvt.c:19:44: note: expected ‘struct dbEntry *’ but argument is of type ‘DBENTRY *’
   19 |                            struct dbEntry *pdbentry)
      |                            ~~~~~~~~~~~~~~~~^~~~~~~~
make[2]: *** [/home/pi/epics/R3.15.9/base/configure/RULES_BUILD:235: devEpicsPvt.o] Error 1
make[2]: Leaving directory '/home/pi/epics/R3.15.9/modules/asyn-R4-45/asyn/O.linux-arm'
make[1]: *** [/home/pi/epics/R3.15.9/base/configure/RULES_ARCHS:58: install.linux-arm] Error 2
make[1]: Leaving directory '/home/pi/epics/R3.15.9/modules/asyn-R4-45/asyn'
make: *** [/home/pi/epics/R3.15.9/base/configure/RULES_DIRS:85: asyn.install] Error 2

$ cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
NAME="Debian GNU/Linux"
VERSION_ID="13"
VERSION="13 (trixie)"
VERSION_CODENAME=trixie
DEBIAN_VERSION_FULL=13.3
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"

```