### PR TITLE
Add a missing exception string

### DIFF
--- a/asyn/asynDriver/asynDriver.h
+++ b/asyn/asynDriver/asynDriver.h
@@ -59,7 +59,8 @@ typedef enum {
 #define ASYN_EXCEPTION_STRINGS                                                          \
     "asynExceptionConnect",   "asynExceptionEnable",      "asynExceptionAutoConnect",   \
     "asynExceptionTraceMask", "asynExceptionTraceIOMask", "asynExceptionTraceInfoMask", \
-    "asynExceptionTraceFile", "asynExceptionTraceIOTruncateSize"
+    "asynExceptionTraceFile", "asynExceptionTraceIOTruncateSize",                       \
+    "asynExceptionShutdown"
 extern  const char * asynExceptionToString( asynException e );
 
 typedef enum {

--- a/asyn/asynRecord/asynRecord.c
+++ b/asyn/asynRecord/asynRecord.c
@@ -2063,7 +2063,7 @@ static void resetError(asynRecord * pasynRec)
 static const char * asynExceptionStrings[] = { ASYN_EXCEPTION_STRINGS };
 const char * asynExceptionToString( asynException e )
 {
-    if ((size_t)e > asynExceptionTraceIOTruncateSize)
+    if ((size_t)e > sizeof(asynExceptionStrings)/sizeof(*asynExceptionStrings))
         return "Invalid Exception Number!";
     return asynExceptionStrings[e];
 }


### PR DESCRIPTION
This fixes the mismatch in the length of the `asynException` enum and  the `ASYN_EXCEPTION_STRINGS` macro. It also fixes the length check in `asynRecord`.